### PR TITLE
Ignore spop binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 *.iml
 *.sock
+spop


### PR DESCRIPTION
Build artifact when using `go build ./cmd/spop` from the repository root.