### PR TITLE
Ignore only spop binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea
 *.iml
 *.sock
-spop
+/spop


### PR DESCRIPTION
Avoid warning upon adding files under cmd/spop/.

(sorry for the oversight)