### PR TITLE
Implement cross domain validation

### DIFF
--- a/berghain.go
+++ b/berghain.go
@@ -16,7 +16,8 @@ type LevelConfig struct {
 }
 
 type Berghain struct {
-	Levels []*LevelConfig
+	Levels         []*LevelConfig
+	TrustedDomains []string
 
 	secret []byte
 	hmac   sync.Pool

--- a/cmd/spop/config.go
+++ b/cmd/spop/config.go
@@ -33,13 +33,20 @@ func (s *Secret) UnmarshalYAML(b []byte) error {
 	return nil
 }
 
-type FrontendConfig []LevelConfig
+type FrontendConfig struct {
+	Levels         []LevelConfig `yaml:"levels"`
+	TrustedDomains []string      `yaml:"trusted_domains"`
+}
 
 func (fc FrontendConfig) AsBerghain(s []byte) *berghain.Berghain {
 	b := berghain.NewBerghain(s)
-	for _, c := range fc {
+
+	for _, c := range fc.Levels {
 		b.Levels = append(b.Levels, c.AsLevelConfig())
 	}
+
+	b.TrustedDomains = fc.TrustedDomains
+
 	return b
 }
 

--- a/cmd/spop/config.yaml
+++ b/cmd/spop/config.yaml
@@ -1,18 +1,24 @@
 secret: JMal0XJRROOMsMdPqggG2tR56CTkpgN3r47GgUN/WSQ=
 
 default:
-  - duration: 24h
-    type: none
-  - duration: 30m
-    type: pow
+  levels:
+    - duration: 24h
+      type: none
+    - duration: 30m
+      type: pow
 
 frontend:
   my_fancy_frontend:
-    - duration: 30s
-      type: none
-      countdown: 9  # default is 3 seconds, maximum is 9
-    - duration: 20s
-      type: pow
-    - duration: 10s
-      type: pow
-      countdown: 0
+    # normally, the exact host is stored and examined during cookie validation
+    # to allow a domain including all of its subdomains to share a validated session, list it here
+    trusted_domains:
+      - foo.example.com
+    levels:
+      - duration: 30s
+        type: none
+        countdown: 9  # default is 3 seconds, maximum is 9
+      - duration: 20s
+        type: pow
+      - duration: 10s
+        type: pow
+        countdown: 0

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -58,7 +58,7 @@ backend berghain_http
 
     acl has_token var(txn.berghain.token) -m found
 
-    http-after-response add-header set-cookie "berghain=%[var(txn.berghain.token)]; path=/;" if has_token
+    http-after-response add-header set-cookie "berghain=%[var(txn.berghain.token)]; domain=%[var(txn.berghain.domain)]; path=/;" if has_token
     http-request return status 200 content-type "application/json" lf-string "%[var(txn.berghain.response)]" if is_challenge_path
 
     http-request return status 404


### PR DESCRIPTION
In environments where services run under multiple subdomains, it can be desirable to not re-challenge a user if they already passed a challenge on a different subdomain.