### PR TITLE
Simplify example HAProxy path rules

### DIFF
--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -29,7 +29,7 @@ frontend test
 
     acl berghain_active var(req.berghain.level) -m found
 
-    acl berghain_path capture.req.uri,url_dec -i -m reg "^/+cdn-cgi/challenge-platform/+"
+    acl berghain_path path /cdn-cgi/challenge-platform/challenge
     http-request send-spoe-group berghain validate if !berghain_path berghain_active
     http-request return status 501 if { var(txn.berghain.error) -m found }
 
@@ -51,7 +51,7 @@ backend berghain_http
     mode http
     filter spoe engine berghain config examples/haproxy/berghain.cfg
 
-    acl is_challenge_path path,url_dec -i -m reg "^/+cdn-cgi/challenge-platform/challenge\$"
+    acl is_challenge_path path /cdn-cgi/challenge-platform/challenge
 
     http-request send-spoe-group berghain challenge if is_challenge_path
     http-request return status 501 if { var(txn.berghain.error) -m found }


### PR DESCRIPTION
The code only requests one static path, no apparent benefit from regular expressions, case-insensitivity and URL decoding, hence make the example easier to comprehend and the rules potentially slightly more efficient.