### PR TITLE
fix: switch to modern Sass JS API

### DIFF
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,6 +3,13 @@ import { viteSingleFile } from "vite-plugin-singlefile";
 import { createHtmlPlugin } from "vite-plugin-html";
 
 export default defineConfig({
+    css: {
+        preprocessorOptions: {
+            scss: {
+                api: 'modern-compiler',
+            },
+        },
+    },
     plugins: [
         viteSingleFile(),
         createHtmlPlugin({


### PR DESCRIPTION
Resolve warning
"Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0"
by switching to the modern API explicitly.

https://sass-lang.com/documentation/breaking-changes/legacy-js-api