### PR TITLE
refactor: prerender json payload with json.Encode

### DIFF
--- a/validator_none.go
+++ b/validator_none.go
@@ -1,18 +1,23 @@
 package berghain
 
-import (
-	"fmt"
-)
-
-const validatorNoneResponse = `{"c": 0, "t": 0}`
+var validatorNoneResponse = mustJSONEncodeString(struct {
+	Countdown int `json:"c"`
+	Type      int `json:"t"`
+}{
+	// Only strings have to be set, as the default is zero for ints.
+	// We do set the Type here because it is static anyway...
+	Type: 0,
+})
 
 func validatorNone(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
 	lc := b.LevelConfig(req.Identifier.Level)
 
 	copy(resp.Body.WriteBytes(), validatorNoneResponse)
-	resp.Body.AdvanceW(6)
-	copy(resp.Body.WriteNBytes(1), fmt.Sprintf("%d", lc.Countdown))
-	resp.Body.AdvanceW(9)
+	resp.Body.AdvanceW(len(`{"c":`))
+	// the following conversion is faster than sprintf but also way uglier, I am sorry.
+	// 48 is the ASCII code for '0', adding lc.Countdown will give us the single correct digit.
+	copy(resp.Body.WriteNBytes(1), []byte{byte(48 + lc.Countdown)})
+	resp.Body.AdvanceW(len(`,"t":0}`))
 
 	return req.Identifier.ToCookie(b, resp.Token)
 }

--- a/validators.go
+++ b/validators.go
@@ -1,6 +1,7 @@
 package berghain
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -75,3 +76,11 @@ func (v ValidationType) RunValidator(b *Berghain, req *ValidatorRequest, resp *V
 }
 
 var errInvalidMethod = fmt.Errorf("invalid method")
+
+func mustJSONEncodeString(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}


### PR DESCRIPTION
By also using the len of the parts between our payloads it should also be easier to understand how this works.