### PR TITLE
fix: handle cookie attribute for non-FQDNs

### DIFF
--- a/cmd/spop/frontend.go
+++ b/cmd/spop/frontend.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"log/slog"
@@ -65,6 +66,14 @@ func getTrustedDomain(host []byte, td []string) []byte {
 	}
 
 	return nil
+}
+
+func getDomainAttr(host []byte) string {
+	if bytes.Contains(host, []byte(".")) {
+		return "domain=" + string(host) + ";" 
+	} else {
+		return ""
+	}
 }
 
 func (f *frontend) HandleSPOEValidate(ctx context.Context, w *encoding.ActionWriter, m *encoding.Message) {
@@ -169,7 +178,7 @@ func (f *frontend) HandleSPOEChallenge(ctx context.Context, w *encoding.ActionWr
 		host = td
 	}
 
-	_ = w.SetString(encoding.VarScopeTransaction, "domain", string(host))
+	_ = w.SetString(encoding.VarScopeTransaction, "domain", getDomainAttr(host))
 
 	hostBuf := acquireHostBuf()
 	defer releaseHostBuf(hostBuf)

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -58,7 +58,7 @@ backend berghain_http
 
     acl has_token var(txn.berghain.token) -m found
 
-    http-after-response add-header set-cookie "berghain=%[var(txn.berghain.token)]; domain=%[var(txn.berghain.domain)]; path=/;" if has_token
+    http-after-response add-header set-cookie "berghain=%[var(txn.berghain.token)]; %[var(txn.berghain.domain)] path=/;" if has_token
     http-request return status 200 content-type "application/json" lf-string "%[var(txn.berghain.response)]" if is_challenge_path
 
     http-request return status 404


### PR DESCRIPTION
The cookie specification does not allow domain attributes with values which are not a domain, causing cookies for requests to hostnames such as "localhost" to not be stored correctly. To avoid configuration overhead in HAProxy, move the attribute key to the variable as well.

Link: https://github.com/DropMorePackets/berghain/issues/37