### PR TITLE
fix: set challenge Content-Type and handle failure

### DIFF
--- a/web/src/challange/challanges.js
+++ b/web/src/challange/challanges.js
@@ -22,10 +22,20 @@ async function challengePOW(challenge){
         }
     }
 
-    await fetch("/cdn-cgi/challenge-platform/challenge", {
-        method: "POST",
-        body: challenge.r + "-" + challenge.s + "-" + i.toString(),
-    });
+    try {
+        const response = await fetch("/cdn-cgi/challenge-platform/challenge", {
+            body: challenge.r + "-" + challenge.s + "-" + i.toString(),
+            headers: {
+                "Content-Type": "text/plain",
+            },
+            method: "POST",
+        });
+        if (!response.ok) {
+            throw new Error("Challenge submission failed");
+        };
+    } catch (error) {
+        console.error(error.message);
+    }
 }
 
 /**


### PR DESCRIPTION
The header _should_ be set according to RFC 7231, hence adding it is
deemed good practice. Whilst at it, improve error handling in case
the backend fails during processing.