### PR TITLE
fix: add wait-for-body to example configuration

### DIFF
--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -36,6 +36,7 @@ frontend test
     acl berghain_valid var(txn.berghain.valid) -m bool
 
     http-request return status 403 content-type "text/html" file "web/dist/index.html" if !berghain_valid !berghain_path berghain_active
+    http-request wait-for-body time 5s if berghain_path METH_POST
     use_backend berghain_http if berghain_path
 
     default_backend app_backend


### PR DESCRIPTION
Sometimes Berghain would not receive the request body, causing repeated challenges.
Grant HAProxy sufficient time to read the body before proceeding with processing to mitigate this.

Link: https://github.com/DropMorePackets/berghain/issues/42