### PR TITLE
feat(web): add build-time challenge hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,60 @@ To run the project using Docker, follow these steps:
 
 Make sure to have Docker and Docker Compose installed on your system before running these commands.
 
+## Customising the challenge page
+
+The frontend build supports two environment variables for operator-owned customisation:
+
+- `VITE_ENTRYPOINT` selects an alternative HTML entrypoint.
+- `VITE_HOOKS` selects a JavaScript file whose labeled phase blocks are compiled directly
+  into the default challenge flow.
+
+Paths may be absolute or relative to the `web/` directory when running the npm scripts. The file
+can contain shared static imports and any of these optional labeled blocks:
+
+- `init` runs after the DOM is ready and before the cookie check.
+- `challengeStart` runs after the challenge is fetched and can access `challenge`.
+- `success` runs before the success UI and can access `challenge` and `countdown`.
+- `failure` runs before the failure UI and can access `challenge`, `countdown`, and `result`.
+
+For example:
+
+```js
+init:{
+    await document.fonts.ready;
+    document.title = "Verifying - Example";
+}
+
+challengeStart:{
+    console.info("Challenge started", challenge.t);
+}
+
+success:{
+    document.documentElement.dataset.challengeStatus = "success";
+    console.info("Challenge passed", {challenge, countdown});
+}
+
+failure:{
+    document.documentElement.dataset.challengeStatus = "failure";
+    console.error("Challenge failed", {challenge, countdown, result});
+}
+```
+
+This example is available as [`web/examples/challenge-page.js`](web/examples/challenge-page.js).
+
+```sh
+cd web
+VITE_HOOKS=./examples/challenge-page.js npm run build:default
+```
+
+The phase blocks are inserted as scoped statements during Vite's transform phase; there is no runtime
+hook registry or callback dispatch. Static imports are resolved relative to the customization file. Top-level
+`await` is supported and delays the next challenge step. Exceptions follow the surrounding challenge flow's
+normal error behavior, and omitted phase blocks are ignored.
+
+The file cannot export values or contain other top-level statements. Phase blocks cannot use top-level
+`var`, dynamic `import()`, `import.meta`, or top-level `arguments`. Environment path changes require
+restarting the Vite development server.
+
 ## Attributions
 Thanks to [@NullDev](https://github.com/NullDev) and [@arellak](https://github.com/arellak), as they did most of the frontend work.

--- a/web/build/inline-hooks.js
+++ b/web/build/inline-hooks.js
@@ -1,0 +1,454 @@
+import {readFile, stat} from "node:fs/promises";
+import {dirname, isAbsolute, relative, resolve, sep} from "node:path";
+import babel from "@babel/core";
+import {searchForWorkspaceRoot} from "vite";
+
+const {parseAsync, transformFromAstAsync, traverse, types} = babel;
+
+const MARKER_TOKEN = "@berghain:inline";
+const SENTINEL = "__BERGHAIN_INLINE_PHASE__";
+
+const PHASE_LABELS = Object.freeze({
+    init: "init",
+    challengeStart: "challenge-start",
+    success: "success",
+    failure: "failure",
+});
+
+const TARGET_PHASES = Object.freeze({
+    "src/main.js": ["init"],
+    "src/challange/challanger.js": ["challenge-start", "failure", "success"],
+});
+
+function cleanId(id){
+    return id.split("?", 1)[0];
+}
+
+function isMissingFile(error){
+    return error?.code === "ENOENT";
+}
+
+function createHooksError(filename, message){
+    return new Error(`Invalid VITE_HOOKS file ${filename}: ${message}`);
+}
+
+function createPhaseError(phase, filename, message){
+    return createHooksError(filename, `phase "${phase}" ${message}`);
+}
+
+function getTargetFiles(root){
+    return new Map(Object.entries(TARGET_PHASES).map(([filename, phases]) => [
+        resolve(root, filename),
+        phases,
+    ]));
+}
+
+function isHooksFile(filename, hooksFile){
+    return hooksFile !== null && resolve(filename) === hooksFile;
+}
+
+async function validateHooksFile(hooksFile){
+    if (!hooksFile){
+        return;
+    }
+
+    let fileStats;
+    try {
+        fileStats = await stat(hooksFile);
+    }
+    catch (error){
+        if (isMissingFile(error)){
+            throw new Error(`VITE_HOOKS file does not exist: ${hooksFile}`);
+        }
+        throw error;
+    }
+
+    if (!fileStats.isFile()){
+        throw new Error(`VITE_HOOKS must point to a JavaScript file: ${hooksFile}`);
+    }
+}
+
+function prepareMarkers(code, filename, expectedPhases){
+    const foundPhases = [];
+    const markerPattern = /^([\t ]*)\/\*[\t ]*@berghain:inline[\t ]+([a-z][a-z0-9-]*)[\t ]*\*\/[\t ]*$/gm;
+    const preparedCode = code.replace(markerPattern, (marker, indentation, phase) => {
+        foundPhases.push(phase);
+        return `${indentation}${SENTINEL}("${phase}");`;
+    });
+    const markerCount = code.split(MARKER_TOKEN).length - 1;
+
+    if (markerCount !== foundPhases.length){
+        throw new Error(`Malformed inline phase marker in ${filename}`);
+    }
+
+    for (const phase of foundPhases){
+        if (!expectedPhases.includes(phase)){
+            throw new Error(`Unknown inline phase "${phase}" in ${filename}`);
+        }
+        if (foundPhases.indexOf(phase) !== foundPhases.lastIndexOf(phase)){
+            throw new Error(`Duplicate inline phase "${phase}" in ${filename}`);
+        }
+    }
+
+    for (const phase of expectedPhases){
+        if (!foundPhases.includes(phase)){
+            throw new Error(`Missing inline phase "${phase}" in ${filename}`);
+        }
+    }
+
+    return preparedCode;
+}
+
+async function parseModule(code, filename){
+    return await parseAsync(code, {
+        babelrc: false,
+        configFile: false,
+        filename,
+        parserOpts: {
+            sourceFilename: filename,
+        },
+        sourceType: "module",
+    });
+}
+
+function getProgramPath(moduleAst){
+    let programPath;
+    traverse(moduleAst, {
+        Program(path){
+            programPath = path;
+            path.stop();
+        },
+    });
+    return programPath;
+}
+
+function getTopLevelPhase(path){
+    const phasePath = path.findParent((parentPath) => (
+        parentPath.isLabeledStatement()
+        && parentPath.parentPath.isProgram()
+    ));
+    if (!phasePath){
+        return null;
+    }
+    return PHASE_LABELS[phasePath.node.label.name] ?? null;
+}
+
+function extractPhases(hooksAst, hooksFile){
+    if (hooksAst.program.directives.length > 0){
+        throw createHooksError(hooksFile, "module directives are not supported");
+    }
+    if (hooksAst.program.interpreter){
+        throw createHooksError(hooksFile, "hashbang directives are not supported");
+    }
+
+    const phases = new Map();
+    const imports = [];
+    const topLevelAwait = new Set();
+
+    for (const statement of hooksAst.program.body){
+        if (types.isImportDeclaration(statement)){
+            imports.push(statement);
+            continue;
+        }
+        if (types.isEmptyStatement(statement)){
+            continue;
+        }
+        if (!types.isLabeledStatement(statement)){
+            throw createHooksError(
+                hooksFile,
+                "top level may only contain static imports and init, challengeStart, success, or failure blocks",
+            );
+        }
+
+        const label = statement.label.name;
+        const phase = PHASE_LABELS[label];
+        if (!phase){
+            throw createHooksError(hooksFile, `unknown phase label "${label}"`);
+        }
+        if (!types.isBlockStatement(statement.body)){
+            throw createPhaseError(phase, hooksFile, "must use a block");
+        }
+        if (phases.has(phase)){
+            throw createPhaseError(phase, hooksFile, "is declared more than once");
+        }
+        phases.set(phase, statement.body.body);
+    }
+
+    traverse(hooksAst, {
+        enter(path){
+            const phase = getTopLevelPhase(path);
+            if (path.isVariableDeclaration({kind: "var"}) && path.getFunctionParent() === null){
+                throw createPhaseError(phase, hooksFile, "cannot use var outside a nested function; use let or const");
+            }
+            if (
+                (path.isAwaitExpression() || (path.isForOfStatement() && path.node.await))
+                && path.getFunctionParent() === null
+                && phase
+            ){
+                topLevelAwait.add(phase);
+            }
+            if (path.isMetaProperty() && path.node.meta.name === "import"){
+                throw createPhaseError(phase, hooksFile, "cannot use import.meta");
+            }
+            if (path.node.type === "Import" || path.node.type === "ImportExpression"){
+                throw createPhaseError(phase, hooksFile, "cannot use dynamic imports; use a static import");
+            }
+            if (path.isReferencedIdentifier({name: "arguments"}) && path.getFunctionParent() === null){
+                throw createPhaseError(phase, hooksFile, "cannot use top-level arguments");
+            }
+            if ((path.isBreakStatement() || path.isContinueStatement()) && path.node.label?.name in PHASE_LABELS){
+                throw createPhaseError(phase, hooksFile, "cannot break or continue a phase label");
+            }
+        },
+    });
+
+    return {imports, phases, topLevelAwait};
+}
+
+function rebaseRelativeImport(importNode, hooksFile, targetFilename){
+    const source = importNode.source.value;
+    if (!source.startsWith(".")){
+        return;
+    }
+
+    const suffixIndex = source.search(/[?#]/);
+    const sourcePath = suffixIndex === -1 ? source : source.slice(0, suffixIndex);
+    const suffix = suffixIndex === -1 ? "" : source.slice(suffixIndex);
+    const absoluteImport = resolve(dirname(hooksFile), sourcePath);
+    let rebasedImport = relative(dirname(targetFilename), absoluteImport).split(sep).join("/");
+
+    if (!rebasedImport.startsWith(".")){
+        rebasedImport = `./${rebasedImport}`;
+    }
+
+    importNode.source.value = `${rebasedImport}${suffix}`;
+    delete importNode.source.extra;
+}
+
+function prepareImports(hooksAst, imports, hooksFile, targetFilename, targetProgramPath){
+    const hooksProgramPath = getProgramPath(hooksAst);
+    for (const importNode of imports){
+        for (const specifier of importNode.specifiers){
+            const localName = specifier.local.name;
+            const uniqueName = targetProgramPath.scope.generateUidIdentifier(`berghain_${localName}`).name;
+            hooksProgramPath.scope.rename(localName, uniqueName);
+        }
+        rebaseRelativeImport(importNode, hooksFile, targetFilename);
+    }
+}
+
+function createPhaseBlock(statements){
+    return types.blockStatement(statements);
+}
+
+function addImports(program, imports){
+    let insertionIndex = 0;
+    while (insertionIndex < program.body.length && types.isImportDeclaration(program.body[insertionIndex])){
+        insertionIndex++;
+    }
+    program.body.splice(insertionIndex, 0, ...imports);
+}
+
+function populateSourcesContent(sourceMap, sourceByFilename, targetFilename){
+    if (!sourceMap){
+        return;
+    }
+
+    sourceMap.sourcesContent = sourceMap.sources.map((source, index) => {
+        const absoluteSource = isAbsolute(source) ? source : resolve(dirname(targetFilename), source);
+        const originalContent = sourceByFilename.get(absoluteSource);
+        if (originalContent !== undefined){
+            return originalContent;
+        }
+        return sourceMap.sourcesContent?.[index] ?? null;
+    });
+}
+
+async function readHooks(hooksFile){
+    if (!hooksFile){
+        return null;
+    }
+
+    const code = await readFile(hooksFile, "utf8");
+    let hooksAst;
+    try {
+        hooksAst = await parseModule(code, hooksFile);
+    }
+    catch (error){
+        throw createHooksError(hooksFile, error.message);
+    }
+
+    return {
+        code,
+        hooksAst,
+        ...extractPhases(hooksAst, hooksFile),
+    };
+}
+
+function invalidateTargets(server, targetFiles){
+    const seen = new Set();
+    const timestamp = Date.now();
+
+    for (const targetFilename of targetFiles.keys()){
+        const modules = server.moduleGraph.getModulesByFile(targetFilename);
+        if (!modules){
+            continue;
+        }
+        for (const moduleNode of modules){
+            server.moduleGraph.invalidateModule(moduleNode, seen, timestamp, true);
+        }
+    }
+
+    server.ws.send({path: "*", type: "full-reload"});
+}
+
+/**
+ * Inline operator-owned labeled phase blocks into the challenge flow at build time.
+ *
+ * @param {object} options
+ * @param {string} options.root Project root.
+ * @param {string|null|undefined} options.hooksFile File containing optional labeled phase blocks.
+ * @return {import("vite").Plugin}
+ */
+export function createInlineHooksPlugin({root, hooksFile}){
+    const absoluteRoot = resolve(root);
+    const absoluteHooksFile = hooksFile ? resolve(hooksFile) : null;
+    const targetFiles = getTargetFiles(absoluteRoot);
+
+    return {
+        name: "berghain-inline-hooks",
+        enforce: "pre",
+
+        config(){
+            if (!absoluteHooksFile){
+                return null;
+            }
+            return {
+                server: {
+                    fs: {
+                        allow: [searchForWorkspaceRoot(absoluteRoot), dirname(absoluteHooksFile)],
+                    },
+                },
+            };
+        },
+
+        async buildStart(){
+            await validateHooksFile(absoluteHooksFile);
+            if (absoluteHooksFile){
+                this.addWatchFile(absoluteHooksFile);
+            }
+        },
+
+        configureServer(server){
+            if (!absoluteHooksFile){
+                return;
+            }
+
+            server.watcher.add(absoluteHooksFile);
+            const reloadAddedOrRemovedFile = (filename) => {
+                if (isHooksFile(filename, absoluteHooksFile)){
+                    invalidateTargets(server, targetFiles);
+                }
+            };
+            server.watcher.on("add", reloadAddedOrRemovedFile);
+            server.watcher.on("unlink", reloadAddedOrRemovedFile);
+        },
+
+        handleHotUpdate({file, server}){
+            if (!isHooksFile(file, absoluteHooksFile)){
+                return undefined;
+            }
+
+            invalidateTargets(server, targetFiles);
+            return [];
+        },
+
+        async transform(code, id){
+            const targetFilename = resolve(cleanId(id));
+            const expectedPhases = targetFiles.get(targetFilename);
+            if (!expectedPhases){
+                return null;
+            }
+
+            try {
+                await validateHooksFile(absoluteHooksFile);
+                if (absoluteHooksFile){
+                    this.addWatchFile(absoluteHooksFile);
+                }
+
+                const preparedCode = prepareMarkers(code, targetFilename, expectedPhases);
+                const targetAst = await parseModule(preparedCode, targetFilename);
+                const targetProgramPath = getProgramPath(targetAst);
+                const hooks = await readHooks(absoluteHooksFile);
+                const sourceByFilename = new Map([[targetFilename, code]]);
+                const phases = new Map();
+                let imports = [];
+
+                if (hooks){
+                    const {imports: hooksImports} = hooks;
+                    sourceByFilename.set(absoluteHooksFile, hooks.code);
+                    const hasTargetPhase = expectedPhases.some((phase) => hooks.phases.has(phase));
+                    if (hasTargetPhase){
+                        prepareImports(
+                            hooks.hooksAst,
+                            hooksImports,
+                            absoluteHooksFile,
+                            targetFilename,
+                            targetProgramPath,
+                        );
+                        imports = hooksImports;
+                    }
+
+                    for (const phase of expectedPhases){
+                        phases.set(phase, {
+                            hasTopLevelAwait: hooks.topLevelAwait.has(phase),
+                            statements: hooks.phases.get(phase) ?? [],
+                        });
+                    }
+                }
+
+                traverse(targetAst, {
+                    ExpressionStatement(path){
+                        const {expression} = path.node;
+                        if (!types.isCallExpression(expression) || !types.isIdentifier(expression.callee, {name: SENTINEL})){
+                            return;
+                        }
+
+                        const [phaseNode] = expression.arguments;
+                        const phase = types.isStringLiteral(phaseNode) ? phaseNode.value : null;
+                        const phaseCode = phases.get(phase);
+                        if (!phaseCode || phaseCode.statements.length === 0){
+                            path.remove();
+                            return;
+                        }
+
+                        if (phaseCode.hasTopLevelAwait && !path.getFunctionParent()?.node.async){
+                            throw createPhaseError(phase, absoluteHooksFile, "uses await at a non-async injection point");
+                        }
+
+                        path.replaceWith(createPhaseBlock(phaseCode.statements));
+                    },
+                });
+
+                addImports(targetAst.program, imports);
+                const transformed = await transformFromAstAsync(targetAst, preparedCode, {
+                    babelrc: false,
+                    cloneInputAst: false,
+                    configFile: false,
+                    filename: targetFilename,
+                    sourceFileName: targetFilename,
+                    sourceMaps: true,
+                });
+
+                populateSourcesContent(transformed.map, sourceByFilename, targetFilename);
+                return {
+                    code: transformed.code,
+                    map: transformed.map,
+                };
+            }
+            catch (error){
+                return this.error(error);
+            }
+        },
+    };
+}

--- a/web/build/inline-hooks.test.js
+++ b/web/build/inline-hooks.test.js
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import {mkdtemp, readFile, rm, writeFile} from "node:fs/promises";
+import {tmpdir} from "node:os";
+import {dirname, join, relative, resolve, sep} from "node:path";
+import {fileURLToPath} from "node:url";
+import {test} from "node:test";
+import {build as viteBuild} from "vite";
+import {createInlineHooksPlugin} from "./inline-hooks.js";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const mainFilename = resolve(root, "src/main.js");
+const challengerFilename = resolve(root, "src/challange/challanger.js");
+
+async function createHooksFile(testContext, code, supportingFiles = {}){
+    const hooksDirectory = await mkdtemp(join(tmpdir(), "berghain-inline-hooks-"));
+    const hooksFile = resolve(hooksDirectory, "hooks.js");
+    testContext.after(async() => await rm(hooksDirectory, {force: true, recursive: true}));
+
+    await writeFile(hooksFile, code);
+    await Promise.all(Object.entries(supportingFiles).map(async([filename, contents]) => {
+        await writeFile(resolve(hooksDirectory, filename), contents);
+    }));
+    return hooksFile;
+}
+
+function createPluginContext(){
+    const watchedFiles = [];
+    return {
+        addWatchFile(filename){
+            watchedFiles.push(filename);
+        },
+        error(error){
+            throw error;
+        },
+        watchedFiles,
+    };
+}
+
+async function transform(plugin, code, id){
+    const context = createPluginContext();
+    const result = await plugin.transform.call(context, code, id);
+    return {context, result};
+}
+
+function expectedRelativeImport(targetFilename, importedFilename){
+    let importPath = relative(dirname(targetFilename), importedFilename).split(sep).join("/");
+    if (!importPath.startsWith(".")){
+        importPath = `./${importPath}`;
+    }
+    return importPath;
+}
+
+test("removes unconfigured inline phases without leaving runtime hooks", async() => {
+    const plugin = createInlineHooksPlugin({hooksFile: null, root});
+    const mainSource = await readFile(mainFilename, "utf8");
+    const challengerSource = await readFile(challengerFilename, "utf8");
+
+    const {result: mainResult} = await transform(plugin, mainSource, mainFilename);
+    const {result: challengerResult} = await transform(plugin, challengerSource, challengerFilename);
+
+    for (const result of [mainResult, challengerResult]){
+        assert.doesNotMatch(result.code, /@berghain:inline|__BERGHAIN_INLINE_PHASE__|createHookInvoker/);
+        assert.ok(result.map);
+    }
+    assert.equal(await plugin.transform.call(createPluginContext(), "const untouched = true;", resolve(root, "src/other.js")), null);
+});
+
+test("inlines labeled, awaited phase blocks with locals and source maps", async(testContext) => {
+    const hooksSource = [
+        "init: {",
+        "    const phaseValue = await Promise.resolve(\"ready\");",
+        "    globalThis.inlineInit = phaseValue;",
+        "}",
+        "challengeStart: {",
+        "    globalThis.inlineChallenge = challenge.t;",
+        "}",
+        "failure: {",
+        "    globalThis.inlineFailure = {challenge, countdown, result};",
+        "    {",
+        "        const result = \"block scoped\";",
+        "        globalThis.inlineLocalResult = result;",
+        "    }",
+        "}",
+        "success: {",
+        "    globalThis.inlineSuccess = {challenge, countdown};",
+        "}",
+        "",
+    ].join("\n");
+    const hooksFile = await createHooksFile(testContext, hooksSource);
+    const plugin = createInlineHooksPlugin({hooksFile, root});
+    const mainSource = await readFile(mainFilename, "utf8");
+    const challengerSource = await readFile(challengerFilename, "utf8");
+
+    const {context: mainContext, result: mainResult} = await transform(plugin, mainSource, mainFilename);
+    const {result: challengerResult} = await transform(plugin, challengerSource, challengerFilename);
+
+    assert.ok(mainResult.code.indexOf("inlineInit") < mainResult.code.indexOf("navigator.cookieEnabled"));
+    assert.ok(challengerResult.code.indexOf("inlineChallenge") < challengerResult.code.lastIndexOf("getChallengeSolver"));
+    assert.ok(challengerResult.code.indexOf("inlineFailure") < challengerResult.code.indexOf("loader.stop"));
+    assert.ok(challengerResult.code.indexOf("inlineSuccess") < challengerResult.code.indexOf("loader.stop"));
+    assert.match(mainResult.code, /await Promise\.resolve\(["']ready["']\)/);
+    assert.match(challengerResult.code, /const result = ["']block scoped["']/);
+    assert.doesNotMatch(mainResult.code, /\btry\b|\bcatch\b|Berghain inline phase/);
+    assert.ok(mainContext.watchedFiles.includes(hooksFile));
+    assert.ok(mainResult.map.sources.includes(hooksFile));
+    assert.equal(mainResult.map.sourcesContent[mainResult.map.sources.indexOf(hooksFile)], hooksSource);
+});
+
+test("rebases shared imports and renames bindings that collide with the target", async(testContext) => {
+    const hooksFile = await createHooksFile(testContext, [
+        "import loader from \"./helper.js\";",
+        "challengeStart: {",
+        "    globalThis.inlineImported = loader(challenge);",
+        "}",
+        "",
+    ].join("\n"), {
+        "helper.js": "export default (challenge) => challenge.t;\n",
+    });
+    const plugin = createInlineHooksPlugin({hooksFile, root});
+    const challengerSource = await readFile(challengerFilename, "utf8");
+
+    const {result} = await transform(plugin, challengerSource, challengerFilename);
+
+    const helperFilename = resolve(dirname(hooksFile), "helper.js");
+    const escapedImport = expectedRelativeImport(challengerFilename, helperFilename).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    assert.match(result.code, new RegExp(escapedImport));
+    assert.match(result.code, /import .* as loader from ["']\.\/loader\.js["']/);
+    assert.doesNotMatch(result.code, /import loader from/);
+    assert.match(result.code, /inlineImported/);
+});
+
+test("rejects old callback modules and invalid phase files", async(testContext) => {
+    const hooksDirectory = await mkdtemp(join(tmpdir(), "berghain-inline-hooks-directory-"));
+    testContext.after(async() => await rm(hooksDirectory, {force: true, recursive: true}));
+    const directoryPlugin = createInlineHooksPlugin({hooksFile: hooksDirectory, root});
+    const mainSource = await readFile(mainFilename, "utf8");
+    await assert.rejects(transform(directoryPlugin, mainSource, mainFilename), /must point to a JavaScript file/);
+
+    const callbackFile = await createHooksFile(testContext, "export default {onInit(){}};\n");
+    const callbackPlugin = createInlineHooksPlugin({hooksFile: callbackFile, root});
+    await assert.rejects(transform(callbackPlugin, mainSource, mainFilename), /top level may only contain/);
+
+    const unknownFile = await createHooksFile(testContext, "unknown: { console.log(\"never\"); }\n");
+    const unknownPlugin = createInlineHooksPlugin({hooksFile: unknownFile, root});
+    await assert.rejects(transform(unknownPlugin, mainSource, mainFilename), /unknown phase label "unknown"/);
+
+    const duplicateFile = await createHooksFile(testContext, "init: {}\ninit: {}\n");
+    const duplicatePlugin = createInlineHooksPlugin({hooksFile: duplicateFile, root});
+    await assert.rejects(transform(duplicatePlugin, mainSource, mainFilename), /phase "init" is declared more than once/);
+
+    const unsupportedFile = await createHooksFile(testContext, "init: { var phaseValue = true; }\n");
+    const unsupportedPlugin = createInlineHooksPlugin({hooksFile: unsupportedFile, root});
+    await assert.rejects(transform(unsupportedPlugin, mainSource, mainFilename), /cannot use var/);
+
+    const escapingFile = await createHooksFile(testContext, "init: { break init; }\n");
+    const escapingPlugin = createInlineHooksPlugin({hooksFile: escapingFile, root});
+    await assert.rejects(transform(escapingPlugin, mainSource, mainFilename), /cannot break or continue/);
+});
+
+test("rejects missing, duplicate, and malformed source markers", async() => {
+    const plugin = createInlineHooksPlugin({hooksFile: null, root});
+    const mainSource = await readFile(mainFilename, "utf8");
+    const marker = "        /* @berghain:inline init */";
+
+    await assert.rejects(transform(plugin, mainSource.replace(marker, ""), mainFilename), /Missing inline phase "init"/);
+    await assert.rejects(transform(plugin, mainSource.replace(marker, `${marker}\n${marker}`), mainFilename), /Duplicate inline phase "init"/);
+    await assert.rejects(transform(plugin, mainSource.replace(marker, "        /* @berghain:inline */"), mainFilename), /Malformed inline phase marker/);
+});
+
+test("Vite builds the repository example without runtime hook machinery", async() => {
+    const hooksFile = resolve(root, "examples/challenge-page.js");
+    const buildResult = await viteBuild({
+        build: {
+            minify: false,
+            rollupOptions: {
+                input: resolve(root, "index.html"),
+            },
+            write: false,
+        },
+        configFile: false,
+        logLevel: "silent",
+        plugins: [createInlineHooksPlugin({hooksFile, root})],
+        root,
+    });
+    const outputs = Array.isArray(buildResult) ? buildResult : [buildResult];
+    const bundledCode = outputs.flatMap(({output}) => output)
+        .filter(({type}) => type === "chunk")
+        .map(({code}) => code)
+        .join("\n");
+
+    assert.match(bundledCode, /Verifying - Example/);
+    assert.match(bundledCode, /challengeStatus/);
+    assert.doesNotMatch(bundledCode, /@berghain:inline|createHookInvoker|berghain-hooks|Berghain (?:hook|inline phase)/);
+});

--- a/web/examples/challenge-page.js
+++ b/web/examples/challenge-page.js
@@ -1,0 +1,18 @@
+init:{
+    await document.fonts.ready;
+    document.title = "Verifying - Example";
+}
+
+challengeStart:{
+    console.info("Challenge started", challenge.t);
+}
+
+success:{
+    document.documentElement.dataset.challengeStatus = "success";
+    console.info("Challenge passed", {challenge, countdown});
+}
+
+failure:{
+    document.documentElement.dataset.challengeStatus = "failure";
+    console.error("Challenge failed", {challenge, countdown, result});
+}

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "build:native-crypto": "vite build --mode native-crypto",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/web/src/challange/challanger.js
+++ b/web/src/challange/challanger.js
@@ -24,13 +24,16 @@ export async function doChallenge(){
     loader.start();
 
     let countdown = 3;
+    let challenge;
     let result;
     try {
         loader.setChallengeInfo("Fetching challenge...");
 
-        const challenge = await getChallenge();
+        challenge = await getChallenge();
         const {t} = challenge;
         countdown = challenge.c;
+
+        /* @berghain:inline challenge-start */
 
         const [name, solver] = getChallengeSolver(t);
 
@@ -42,6 +45,13 @@ export async function doChallenge(){
     }
     catch (e){
         result = e.toString();
+    }
+
+    if (result){
+        /* @berghain:inline failure */
+    }
+    else {
+        /* @berghain:inline success */
     }
 
     loader.stop(countdown, !!result);

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -4,6 +4,8 @@ import {doChallenge} from "./challange/challanger";
 
 (() => {
     window.addEventListener("DOMContentLoaded", async() => {
+        /* @berghain:inline init */
+
         if (!navigator.cookieEnabled){
             const noCookie = document.getElementById("no-cookie");
             noCookie.style.display = "block";

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,14 +3,22 @@ import {dirname, resolve, join} from "node:path";
 import {defineConfig, loadEnv} from "vite";
 import {viteSingleFile} from "vite-plugin-singlefile";
 import {createHtmlPlugin} from "vite-plugin-html";
+import {createInlineHooksPlugin} from "./build/inline-hooks.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(({mode}) => {
     const env = loadEnv(mode, process.cwd(), "");
+    const hooksFile = env.VITE_HOOKS
+        ? resolve(process.cwd(), env.VITE_HOOKS)
+        : null;
 
     return {
         plugins: [
+            createInlineHooksPlugin({
+                hooksFile,
+                root: __dirname,
+            }),
             viteSingleFile(),
             createHtmlPlugin({
                 minify: true,


### PR DESCRIPTION
## What

- Add build-time `VITE_HOOKS` module injection for `onInit`, `onChallengeStart`, `onSuccess`, and `onFailure`.
- Isolate hook failures from verification, including rejected asynchronous callbacks.
- Document custom HTML entrypoints and hook modules.

## Why

Operators need to brand or instrument the challenge page without forking the frontend. Hooks are trusted build-time code and remain non-blocking at runtime.

Closes #26.

## Validation

- `npm test`
- `npm run lint`
- `npm run build`
- `git diff --check`