### PR TITLE
feat: configure proof-of-work difficulty

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,19 @@ For Debian / Ubuntu: apt install npm
 
 For production use, generate a random `secret` to place in the Berghain configuration file using `openssl rand -base64 32`.
 
+### Proof-of-work difficulty
+
+Each `pow` level can set `difficulty` to the required number of leading zero bits:
+
+```yaml
+levels:
+  - duration: 30m
+    type: pow
+    difficulty: 20
+```
+
+The default is `16`; explicit values must be between `1` and `255`. Higher values increase browser work exponentially, so raise the value carefully.
+
 ## Running with Docker
 
 To run the project using Docker, follow these steps:

--- a/berghain.go
+++ b/berghain.go
@@ -13,6 +13,11 @@ type LevelConfig struct {
 	Countdown int
 	Duration  time.Duration
 	Type      ValidationType
+
+	// Difficulty is the number of leading zero bits required for POW. A zero
+	// value uses DefaultPOWDifficulty; other values must be within the documented
+	// MinPOWDifficulty..MaxPOWDifficulty range.
+	Difficulty int
 }
 
 type Berghain struct {

--- a/cmd/spop/config.go
+++ b/cmd/spop/config.go
@@ -51,9 +51,10 @@ func (fc FrontendConfig) AsBerghain(s []byte) *berghain.Berghain {
 }
 
 type LevelConfig struct {
-	Countdown *int          `yaml:"countdown"`
-	Duration  time.Duration `yaml:"duration"`
-	Type      string        `yaml:"type"`
+	Countdown  *int          `yaml:"countdown"`
+	Duration   time.Duration `yaml:"duration"`
+	Type       string        `yaml:"type"`
+	Difficulty *int          `yaml:"difficulty"`
 }
 
 func (c LevelConfig) AsLevelConfig() *berghain.LevelConfig {
@@ -70,6 +71,13 @@ func (c LevelConfig) AsLevelConfig() *berghain.LevelConfig {
 		Fatal("countdown too high, cannot proceed", "countdown_have", *c.Countdown, "countdown_max", 9)
 	} else {
 		lc.Countdown = *c.Countdown
+	}
+
+	if c.Difficulty != nil {
+		if err := berghain.ValidatePOWDifficulty(*c.Difficulty); err != nil {
+			Fatal("invalid POW difficulty, cannot proceed", "difficulty", *c.Difficulty, "error", err)
+		}
+		lc.Difficulty = *c.Difficulty
 	}
 
 	switch c.Type {

--- a/cmd/spop/config.yaml
+++ b/cmd/spop/config.yaml
@@ -19,6 +19,9 @@ frontend:
         countdown: 9  # default is 3 seconds, maximum is 9
       - duration: 20s
         type: pow
+        # Leading zero bits required from the proof. Default: 16; range: 1-255.
+        difficulty: 16
       - duration: 10s
         type: pow
         countdown: 0
+        difficulty: 22

--- a/docs/index.html
+++ b/docs/index.html
@@ -309,7 +309,8 @@
           <p>A level can require a proof-of-work: your browser must find an input whose hash begins
             with a run of zero bits. It is deliberately cheap for one genuine visitor but costly to
             repeat across a bot farm. The computation runs entirely in your browser &mdash; the server
-            only hands out the puzzle and checks the answer.</p>
+            only hands out the puzzle and checks the answer. Operators can tune the number of required
+            zero bits per level; the default is 16 and higher values increase the work exponentially.</p>
         </div>
       </details>
     </div>

--- a/validator_pow.go
+++ b/validator_pow.go
@@ -34,19 +34,27 @@ const (
 	validatorPOWRandom            = "0000000000000000"
 	validatorPOWHash              = "0000000000000000000000000000000000000000000000000000000000000000"
 	validatorPOWMinSolutionLength = len(validatorPOWRandom + "-" + validatorPOWHash + "-0")
+
+	DefaultPOWDifficulty = 16
+	MinPOWDifficulty     = 1
+	MaxPOWDifficulty     = 255
 )
 
+const hexdigits = "0123456789abcdef"
+
 var validatorPOWChallengeTemplate = mustJSONEncodeString(struct {
-	Countdown int    `json:"c"`
-	Type      int    `json:"t"`
-	Random    string `json:"r"`
-	Hash      string `json:"s"`
+	Countdown  int    `json:"c"`
+	Type       int    `json:"t"`
+	Difficulty string `json:"d"`
+	Random     string `json:"r"`
+	Hash       string `json:"s"`
 }{
 	// Only strings have to be set, as the default is zero for ints.
 	// We do set the Type here because it is static anyway...
-	Type:   1,
-	Random: "0000000000000000",
-	Hash:   "0000000000000000000000000000000000000000000000000000000000000000",
+	Type:       1,
+	Difficulty: "00",
+	Random:     validatorPOWRandom,
+	Hash:       validatorPOWHash,
 })
 
 // This prevents invalid template strings by validatoring them on start
@@ -63,6 +71,10 @@ func (powValidator) onNew(b *Berghain, req *ValidatorRequest, resp *ValidatorRes
 	defer b.releaseHMAC(h)
 
 	lc := b.LevelConfig(req.Identifier.Level)
+	difficulty, err := effectivePOWDifficulty(lc.Difficulty)
+	if err != nil {
+		return err
+	}
 
 	copy(resp.Body.WriteBytes(), validatorPOWChallengeTemplate)
 
@@ -70,7 +82,11 @@ func (powValidator) onNew(b *Berghain, req *ValidatorRequest, resp *ValidatorRes
 	// the following conversion is faster than sprintf but also way uglier, I am sorry.
 	// 48 is the ASCII code for '0', adding lc.Countdown will give us the single correct digit.
 	copy(resp.Body.WriteNBytes(1), []byte{byte(48 + lc.Countdown)})
-	resp.Body.AdvanceW(len(`,"t":1,"r":"`))
+	resp.Body.AdvanceW(len(`,"t":1,"d":"`))
+	difficultyArea := resp.Body.WriteNBytes(2)
+	difficultyArea[0] = hexdigits[difficulty>>4]
+	difficultyArea[1] = hexdigits[difficulty&0x0f]
+	resp.Body.AdvanceW(len(`","r":"`))
 	timestampArea := resp.Body.WriteNBytes(len(validatorPOWRandom))
 	resp.Body.AdvanceW(len(`","s":"`))
 	hexArea := resp.Body.WriteNBytes(hex.EncodedLen(h.Size()))
@@ -94,8 +110,12 @@ func (powValidator) onNew(b *Berghain, req *ValidatorRequest, resp *ValidatorRes
 }
 
 func (powValidator) isValid(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
-	// req.Body should be at least validatorPOWMinSolutionLength
-	if len(req.Body) <= validatorPOWMinSolutionLength {
+	difficulty, err := effectivePOWDifficulty(b.LevelConfig(req.Identifier.Level).Difficulty)
+	if err != nil {
+		return err
+	}
+
+	if len(req.Body) < validatorPOWMinSolutionLength {
 		// invalid solution data
 		return ErrInvalidLength
 	}
@@ -142,14 +162,51 @@ func (powValidator) isValid(b *Berghain, req *ValidatorRequest, resp *ValidatorR
 	defer releaseSHA256(sha)
 
 	sha.Write(timestampArea)
+	sha.Write(sumArea)
 	sha.Write(solArea)
 	sum := sha.Sum(nil)
 
-	if !bytes.HasPrefix(sum, []byte{0x00, 0x00}) {
+	if !hasLeadingZeroBits(sum, int(difficulty)) {
 		return errInvalidSolution
 	}
 
 	return nil
+}
+
+// ValidatePOWDifficulty checks an explicit configured difficulty. The zero
+// value is reserved for LevelConfig's backward-compatible default and is
+// normalized by effectivePOWDifficulty.
+func ValidatePOWDifficulty(difficulty int) error {
+	if difficulty < MinPOWDifficulty || difficulty > MaxPOWDifficulty {
+		return fmt.Errorf("difficulty must be between %d and %d", MinPOWDifficulty, MaxPOWDifficulty)
+	}
+	return nil
+}
+
+func effectivePOWDifficulty(difficulty int) (uint8, error) {
+	if difficulty == 0 {
+		return DefaultPOWDifficulty, nil
+	}
+	if err := ValidatePOWDifficulty(difficulty); err != nil {
+		return 0, err
+	}
+	return uint8(difficulty), nil
+}
+
+func hasLeadingZeroBits(b []byte, bits int) bool {
+	if bits < 0 || bits > len(b)*8 {
+		return false
+	}
+
+	wholeBytes := bits / 8
+	for i := 0; i < wholeBytes; i++ {
+		if b[i] != 0 {
+			return false
+		}
+	}
+
+	remainingBits := bits % 8
+	return remainingBits == 0 || b[wholeBytes]>>(8-remainingBits) == 0
 }
 
 var errInvalidSolution = fmt.Errorf("invalid solution")

--- a/validator_pow_test.go
+++ b/validator_pow_test.go
@@ -2,6 +2,7 @@ package berghain
 
 import (
 	"bytes"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -11,17 +12,24 @@ import (
 	"time"
 )
 
+type powChallenge struct {
+	T int    `json:"t"`
+	D string `json:"d"`
+	R string `json:"r"`
+	S string `json:"s"`
+}
+
+func decodePOWChallenge(b []byte) (powChallenge, error) {
+	var challenge powChallenge
+	err := json.NewDecoder(bytes.NewReader(b)).Decode(&challenge)
+	return challenge, err
+}
+
 func solvePOW(tb testing.TB, b []byte) ([]byte, error) {
 	tb.Helper()
 
-	type powChallenge struct {
-		T int    `json:"t"`
-		R string `json:"r"`
-		S string `json:"s"`
-	}
-
-	var p powChallenge
-	if err := json.NewDecoder(bytes.NewReader(b)).Decode(&p); err != nil {
+	p, err := decodePOWChallenge(b)
+	if err != nil {
 		return nil, err
 	}
 
@@ -29,14 +37,20 @@ func solvePOW(tb testing.TB, b []byte) ([]byte, error) {
 		return nil, fmt.Errorf("invalid challenge type: %d", p.T)
 	}
 
+	difficulty, err := strconv.ParseInt(p.D, 16, 0)
+	if err != nil {
+		return nil, fmt.Errorf("invalid difficulty %q: %w", p.D, err)
+	}
+
 	h := NewZeroHasher(hashAlgo())
 	for i := 0; true; i++ {
 		h.Write([]byte(p.R))
+		h.Write([]byte(p.S))
 
 		is := strconv.Itoa(i)
 		h.Write([]byte(is))
 
-		if bytes.HasPrefix(h.Sum(nil), []byte{0x00, 0x00}) {
+		if hasLeadingZeroBits(h.Sum(nil), int(difficulty)) {
 			solution := p.R + "-" + p.S + "-" + is
 			return []byte(solution), nil
 		}
@@ -44,6 +58,188 @@ func solvePOW(tb testing.TB, b []byte) ([]byte, error) {
 		h.Reset()
 	}
 	panic("unreachable")
+}
+
+func powDigest(random, signature, nonce string) []byte {
+	h := hashAlgo()
+	_, _ = h.Write([]byte(random))
+	_, _ = h.Write([]byte(signature))
+	_, _ = h.Write([]byte(nonce))
+	return h.Sum(nil)
+}
+
+func challengeSignature(tb testing.TB, b *Berghain, identifier RequestIdentifier, random string) string {
+	tb.Helper()
+
+	h := b.acquireHMAC()
+	defer b.releaseHMAC(h)
+	if _, err := identifier.WriteTo(h); err != nil {
+		tb.Fatal(err)
+	}
+	if _, err := h.Write([]byte(random)); err != nil {
+		tb.Fatal(err)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func TestValidatePOWDifficulty(t *testing.T) {
+	for _, difficulty := range []int{MinPOWDifficulty, DefaultPOWDifficulty, MaxPOWDifficulty} {
+		if err := ValidatePOWDifficulty(difficulty); err != nil {
+			t.Errorf("ValidatePOWDifficulty(%d) returned %v", difficulty, err)
+		}
+	}
+	for _, difficulty := range []int{-1, 0, MaxPOWDifficulty + 1} {
+		if err := ValidatePOWDifficulty(difficulty); err == nil {
+			t.Errorf("ValidatePOWDifficulty(%d) unexpectedly succeeded", difficulty)
+		}
+	}
+}
+
+func TestEffectivePOWDifficulty(t *testing.T) {
+	if got, err := effectivePOWDifficulty(0); err != nil || got != DefaultPOWDifficulty {
+		t.Errorf("effectivePOWDifficulty(0) = %d, %v; want %d, nil", got, err, DefaultPOWDifficulty)
+	}
+	for _, difficulty := range []int{-1, MaxPOWDifficulty + 1} {
+		if _, err := effectivePOWDifficulty(difficulty); err == nil {
+			t.Errorf("effectivePOWDifficulty(%d) unexpectedly succeeded", difficulty)
+		}
+	}
+}
+
+func TestHasLeadingZeroBits(t *testing.T) {
+	tests := []struct {
+		name string
+		b    []byte
+		bits int
+		want bool
+	}{
+		{name: "zero bits", b: []byte{0xff}, bits: 0, want: true},
+		{name: "partial byte", b: []byte{0x7f}, bits: 1, want: true},
+		{name: "partial byte set", b: []byte{0x80}, bits: 1, want: false},
+		{name: "whole byte", b: []byte{0x00, 0xff}, bits: 8, want: true},
+		{name: "whole and partial", b: []byte{0x00, 0x0f}, bits: 12, want: true},
+		{name: "whole and partial set", b: []byte{0x00, 0x10}, bits: 12, want: false},
+		{name: "too many bits", b: []byte{0x00}, bits: 9, want: false},
+		{name: "negative bits", b: []byte{0x00}, bits: -1, want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasLeadingZeroBits(tt.b, tt.bits); got != tt.want {
+				t.Errorf("hasLeadingZeroBits(%x, %d) = %t, want %t", tt.b, tt.bits, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidatorPOWDifficulty(t *testing.T) {
+	for _, difficulty := range []int{0, 1, 8, 12, MaxPOWDifficulty} {
+		t.Run(strconv.Itoa(difficulty), func(t *testing.T) {
+			bh := NewBerghain(generateSecret(t))
+			bh.Levels = []*LevelConfig{{
+				Duration:   time.Minute,
+				Type:       ValidationTypePOW,
+				Difficulty: difficulty,
+			}}
+			req, resp := AcquireValidatorRequest(), AcquireValidatorResponse()
+			defer ReleaseValidatorRequest(req)
+			defer ReleaseValidatorResponse(resp)
+			req.Identifier = &RequestIdentifier{
+				SrcAddr: netip.MustParseAddr("1.2.3.4"),
+				Host:    []byte("example.com"),
+				Level:   1,
+			}
+			req.Method = http.MethodGet
+
+			if err := validatorPOW(bh, req, resp); err != nil {
+				t.Fatalf("validatorPOW: %v", err)
+			}
+			challenge, err := decodePOWChallenge(resp.Body.ReadBytes())
+			if err != nil {
+				t.Fatal(err)
+			}
+			wantDifficulty := difficulty
+			if wantDifficulty == 0 {
+				wantDifficulty = DefaultPOWDifficulty
+			}
+			if want := fmt.Sprintf("%02x", wantDifficulty); challenge.D != want {
+				t.Errorf("difficulty = %q, want %q", challenge.D, want)
+			}
+
+			// Avoid attempting intentionally impractical work at the maximum.
+			if difficulty == MaxPOWDifficulty {
+				return
+			}
+			solution, err := solvePOW(t, resp.Body.ReadBytes())
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Method = http.MethodPost
+			req.Body = solution
+			if err := validatorPOW(bh, req, resp); err != nil {
+				t.Fatalf("validating solution: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidatorPOWRejectsInvalidDirectDifficulty(t *testing.T) {
+	for _, difficulty := range []int{-1, MaxPOWDifficulty + 1} {
+		bh := NewBerghain(generateSecret(t))
+		bh.Levels = []*LevelConfig{{Type: ValidationTypePOW, Difficulty: difficulty}}
+		req, resp := AcquireValidatorRequest(), AcquireValidatorResponse()
+		req.Identifier = &RequestIdentifier{Level: 1}
+		req.Method = http.MethodGet
+		if err := validatorPOW(bh, req, resp); err == nil {
+			t.Errorf("difficulty %d unexpectedly succeeded", difficulty)
+		}
+		ReleaseValidatorRequest(req)
+		ReleaseValidatorResponse(resp)
+	}
+}
+
+func TestValidatorPOWBindsWorkToSignature(t *testing.T) {
+	const difficulty = 8
+
+	bh := NewBerghain(generateSecret(t))
+	bh.Levels = []*LevelConfig{{Duration: time.Minute, Type: ValidationTypePOW, Difficulty: difficulty}}
+	firstIdentifier := RequestIdentifier{
+		SrcAddr: netip.MustParseAddr("1.2.3.4"),
+		Host:    []byte("example.com"),
+		Level:   1,
+	}
+	secondIdentifier := firstIdentifier
+	secondIdentifier.SrcAddr = netip.MustParseAddr("1.2.3.5")
+
+	req, resp := AcquireValidatorRequest(), AcquireValidatorResponse()
+	defer ReleaseValidatorRequest(req)
+	defer ReleaseValidatorResponse(resp)
+	req.Identifier = &firstIdentifier
+	req.Method = http.MethodGet
+	if err := validatorPOW(bh, req, resp); err != nil {
+		t.Fatal(err)
+	}
+	challenge, err := decodePOWChallenge(resp.Body.ReadBytes())
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondSignature := challengeSignature(t, bh, secondIdentifier, challenge.R)
+
+	var nonce string
+	for i := 0; ; i++ {
+		candidate := strconv.Itoa(i)
+		if hasLeadingZeroBits(powDigest(challenge.R, challenge.S, candidate), difficulty) &&
+			!hasLeadingZeroBits(powDigest(challenge.R, secondSignature, candidate), difficulty) {
+			nonce = candidate
+			break
+		}
+	}
+
+	req.Identifier = &secondIdentifier
+	req.Method = http.MethodPost
+	req.Body = []byte(challenge.R + "-" + secondSignature + "-" + nonce)
+	if err := validatorPOW(bh, req, resp); err != errInvalidSolution {
+		t.Fatalf("reused work returned %v, want %v", err, errInvalidSolution)
+	}
 }
 
 func Test_validatorPOW(t *testing.T) {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "build:native-crypto": "vite build --mode native-crypto",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/web/src/challange/challanges.js
+++ b/web/src/challange/challanges.js
@@ -2,18 +2,7 @@
  * Collection of challenges.
  */
 
-import {sha256} from "@noble/hashes/sha256";
-import {bytesToHex} from "@noble/hashes/utils";
-
-async function doHash(data){
-    const input = new TextEncoder().encode(data);
-
-    if (import.meta.env.VITE_NATIVE_CRYPTO === "true"){
-        const hashBuffer = await crypto.subtle.digest("sha-256", input);
-        return bytesToHex(new Uint8Array(hashBuffer));
-    }
-    return bytesToHex(sha256(input));
-}
+import {doHash, hasLeadingZeroBits, parsePOWDifficulty, powInput} from "./pow.js";
 
 /**
  * Challenge POW.
@@ -22,31 +11,26 @@ async function doHash(data){
  * @return {Promise<void>}
  */
 async function challengePOW(challenge){
-    let hash;
+    const difficulty = parsePOWDifficulty(challenge.d);
     let i;
 
     // eslint-disable-next-line no-constant-condition
     for (i = 0; true; i++){
-        hash = await doHash(challenge.r + i.toString());
-        if (hash.startsWith("0000")){
+        const hash = await doHash(powInput(challenge, i));
+        if (hasLeadingZeroBits(hash, difficulty)){
             break;
         }
     }
 
-    try {
-        const response = await fetch("/cdn-cgi/challenge-platform/challenge", {
-            body: challenge.r + "-" + challenge.s + "-" + i.toString(),
-            headers: {
-                "Content-Type": "text/plain",
-            },
-            method: "POST",
-        });
-        if (!response.ok){
-            throw new Error("Challenge submission failed");
-        }
-    }
-    catch (error){
-        console.error(error.message);
+    const response = await fetch("/cdn-cgi/challenge-platform/challenge", {
+        body: challenge.r + "-" + challenge.s + "-" + i.toString(),
+        headers: {
+            "Content-Type": "text/plain",
+        },
+        method: "POST",
+    });
+    if (!response.ok){
+        throw new Error(`Challenge submission failed (${response.status})`);
     }
 }
 

--- a/web/src/challange/pow.js
+++ b/web/src/challange/pow.js
@@ -1,0 +1,80 @@
+/**
+ * Proof-of-work primitives shared by the browser solver and its tests.
+ */
+
+import {sha256} from "@noble/hashes/sha256";
+
+export const defaultPOWDifficulty = 16;
+
+/**
+ * Decode the server's fixed-width hexadecimal difficulty. Older servers do not
+ * send the field, so an absent value retains the historic 16-bit target.
+ *
+ * @param {unknown} encoded
+ * @return {number}
+ */
+export function parsePOWDifficulty(encoded){
+    if (encoded === undefined || encoded === null){
+        return defaultPOWDifficulty;
+    }
+    if (typeof encoded !== "string" || !/^[0-9a-f]{2}$/iu.test(encoded)){
+        throw new Error("Invalid POW difficulty");
+    }
+
+    const difficulty = Number.parseInt(encoded, 16);
+    if (difficulty < 1 || difficulty > 255){
+        throw new Error("Invalid POW difficulty");
+    }
+    return difficulty;
+}
+
+/**
+ * New challenges bind work to both authenticated fields so a nonce cannot be
+ * reused with another client's signature. A missing difficulty identifies the
+ * legacy wire format, whose work input contained only the random field.
+ *
+ * @param {{r: string, s: string}} challenge
+ * @param {number} nonce
+ * @return {string}
+ */
+export function powInput(challenge, nonce){
+    if (challenge.d === undefined || challenge.d === null){
+        return challenge.r + nonce.toString();
+    }
+    return challenge.r + challenge.s + nonce.toString();
+}
+
+/**
+ * @param {string} data
+ * @return {Promise<Uint8Array>}
+ */
+export async function doHash(data){
+    const input = new TextEncoder().encode(data);
+
+    if (import.meta.env?.VITE_NATIVE_CRYPTO === "true"){
+        const hashBuffer = await crypto.subtle.digest("sha-256", input);
+        return new Uint8Array(hashBuffer);
+    }
+    return sha256(input);
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number} bits
+ * @return {boolean}
+ */
+export function hasLeadingZeroBits(bytes, bits){
+    if (!Number.isInteger(bits) || bits < 0 || bits > bytes.length * 8){
+        return false;
+    }
+
+    const wholeBytes = Math.floor(bits / 8);
+    for (let i = 0; i < wholeBytes; i++){
+        if (bytes[i] !== 0){
+            return false;
+        }
+    }
+
+    const remainingBits = bits % 8;
+    return remainingBits === 0 || (bytes[wholeBytes] >> (8 - remainingBits)) === 0;
+}

--- a/web/src/challange/pow.test.js
+++ b/web/src/challange/pow.test.js
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {getChallengeSolver} from "./challanges.js";
+import {
+    defaultPOWDifficulty,
+    doHash,
+    hasLeadingZeroBits,
+    parsePOWDifficulty,
+    powInput,
+} from "./pow.js";
+
+test("difficulty defaults to the historic target", () => {
+    assert.equal(parsePOWDifficulty(undefined), defaultPOWDifficulty);
+    assert.equal(parsePOWDifficulty("01"), 1);
+    assert.equal(parsePOWDifficulty("ff"), 255);
+    assert.throws(() => parsePOWDifficulty("00"), /Invalid POW difficulty/u);
+    assert.throws(() => parsePOWDifficulty("100"), /Invalid POW difficulty/u);
+});
+
+test("leading zero bits supports partial bytes and rejects out-of-range input", () => {
+    assert.equal(hasLeadingZeroBits(Uint8Array.of(0x00, 0x0f), 12), true);
+    assert.equal(hasLeadingZeroBits(Uint8Array.of(0x00, 0x10), 12), false);
+    assert.equal(hasLeadingZeroBits(Uint8Array.of(0x00), 9), false);
+});
+
+test("work input includes the authenticated challenge signature", () => {
+    const challenge = {d: "10", r: "timestamp", s: "signature-a"};
+    assert.equal(powInput(challenge, 7), "timestampsignature-a7");
+    assert.notEqual(powInput(challenge, 7), powInput({...challenge, s: "signature-b"}, 7));
+});
+
+test("a challenge without difficulty uses the legacy work input", () => {
+    assert.equal(powInput({r: "timestamp", s: "signature"}, 7), "timestamp7");
+});
+
+test("a non-successful solution submission rejects", async(t) => {
+    const originalFetch = globalThis.fetch;
+    t.after(() => {
+        globalThis.fetch = originalFetch;
+    });
+    globalThis.fetch = async() => ({ok: false, status: 429});
+
+    const [, solve] = getChallengeSolver(1);
+    await assert.rejects(
+        solve({d: "01", r: "timestamp", s: "signature"}),
+        /Challenge submission failed \(429\)/u,
+    );
+});
+
+test("hashing produces a SHA-256 digest", async() => {
+    const digest = await doHash("proof");
+    assert.equal(digest.length, 32);
+});


### PR DESCRIPTION
## What

- Add per-level POW difficulty in leading zero bits, with a backward-compatible default of 16 and an explicit range of 1-255.
- Advertise difficulty in the challenge wire format and enforce the configured value on the server.
- Bind work to the authenticated challenge signature by hashing `r + s + nonce`.
- Reject failed solution submissions in the browser instead of continuing as if verification succeeded.

## Why

The omnibus implementation made difficulty configurable but left solved nonces reusable across different signed challenges. This version centralizes validation and binds the work to the client-specific signature.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `staticcheck ./...`
- `npm test`
- `npm run lint`
- `npm run build`