### PR TITLE
feat(haproxy): add request admission limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,5 +54,16 @@ To run the project using Docker, follow these steps:
 
 Make sure to have Docker and Docker Compose installed on your system before running these commands.
 
+## HAProxy request limits
+
+The example HAProxy frontend applies two admission controls before it invokes Berghain:
+
+- `rate-limit sessions` bounds newly accepted sessions across the frontend.
+- A one-second, per-source stick table returns `429 Too Many Requests` for bursts above the
+  example threshold. Challenge requests are excluded so a verification POST is not throttled.
+
+These values are examples rather than universal production defaults. Tune them for the expected
+traffic profile and capacity of the protected service.
+
 ## Attributions
 Thanks to [@NullDev](https://github.com/NullDev) and [@arellak](https://github.com/arellak), as they did most of the frontend work.

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -19,6 +19,17 @@ frontend test
     bind *:8080
     log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %ID spoa-error:\ %[var(txn.berghain.error)]"
 
+    # Bound total admission and short per-source bursts before doing challenge work.
+    maxconn 20000
+    rate-limit sessions 5000
+
+    acl berghain_path path /cdn-cgi/challenge-platform/challenge
+
+    # sc0 is dedicated to the one-second burst window. Challenge traffic is
+    # excluded so verification requests are not throttled by the generic limit.
+    http-request track-sc0 src table st_burst if !berghain_path
+    http-request return status 429 content-type "application/json" string '{"error":"rate_limited"}' hdr "Retry-After" "1" if !berghain_path { sc0_http_req_rate(st_burst) gt 30 }
+
     http-request track-sc1 src table st_src
 
     filter spoe engine berghain config examples/haproxy/berghain.cfg
@@ -29,7 +40,6 @@ frontend test
 
     acl berghain_active var(req.berghain.level) -m found
 
-    acl berghain_path path /cdn-cgi/challenge-platform/challenge
     http-request send-spoe-group berghain validate if !berghain_path berghain_active
     http-request return status 501 if { var(txn.berghain.error) -m found }
 
@@ -45,6 +55,9 @@ frontend test
 
 backend st_src
     stick-table type ipv6 size 1m expire 15m store http_req_rate(10s)
+
+backend st_burst
+    stick-table type ipv6 size 1m expire 1m store http_req_rate(1s)
 
 backend app_backend
     mode http


### PR DESCRIPTION
## What

- Bound total new sessions in the example frontend.
- Add a dedicated one-second per-source burst table and return `429` with `Retry-After` above the example threshold.
- Exempt challenge requests from the generic burst limiter.
- Document that the example limits must be capacity-tuned per deployment.

## Why

Admission control should happen in HAProxy before expensive challenge work or backend traffic.

## Validation

- HAProxy 3.3 configuration validation
- Full-stack integration configuration validation
- `git diff --check`