### PR TITLE
feat(haproxy): add atomic Runtime API map updates

### DIFF
--- a/internal/haproxyruntime/maps.go
+++ b/internal/haproxyruntime/maps.go
@@ -1,0 +1,166 @@
+// Package haproxyruntime provides the small subset of HAProxy's Runtime API
+// needed by Berghain's operational helpers.
+package haproxyruntime
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode"
+)
+
+const (
+	defaultTimeout            = 5 * time.Second
+	defaultTransactionTimeout = 2 * time.Minute
+	maxResponseSize           = 1 << 20
+	maxTransactionEntries     = 20_000
+)
+
+// Client sends commands to an HAProxy Runtime API UNIX socket.
+type Client struct {
+	SocketPath         string
+	Timeout            time.Duration
+	TransactionTimeout time.Duration
+}
+
+// ReplaceMap atomically replaces a runtime map with entries. HAProxy creates a
+// temporary version, receives every entry, and exposes it only after commit.
+func (c Client) ReplaceMap(ctx context.Context, mapRef string, entries map[string]string) error {
+	if len(entries) > maxTransactionEntries {
+		return fmt.Errorf("map has %d entries; transaction limit is %d", len(entries), maxTransactionEntries)
+	}
+	transactionTimeout := c.TransactionTimeout
+	if transactionTimeout <= 0 {
+		transactionTimeout = defaultTransactionTimeout
+	}
+	ctx, cancel := context.WithTimeout(ctx, transactionTimeout)
+	defer cancel()
+
+	if err := validateToken("map reference", mapRef); err != nil {
+		return err
+	}
+
+	keys := make([]string, 0, len(entries))
+	for key, value := range entries {
+		if err := validateToken("map key", key); err != nil {
+			return err
+		}
+		if err := validateToken("map value", value); err != nil {
+			return err
+		}
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	response, err := c.command(ctx, "prepare map "+mapRef)
+	if err != nil {
+		return fmt.Errorf("prepare map: %w", err)
+	}
+	version, err := parseVersion(response)
+	if err != nil {
+		return fmt.Errorf("prepare map: %w", err)
+	}
+
+	transaction := "@" + strconv.FormatUint(version, 10)
+	for _, key := range keys {
+		command := strings.Join([]string{"add map", transaction, mapRef, key, entries[key]}, " ")
+		if err := c.silentCommand(ctx, command); err != nil {
+			return fmt.Errorf("add map entry %q: %w", key, err)
+		}
+	}
+
+	if err := c.silentCommand(ctx, strings.Join([]string{"commit map", transaction, mapRef}, " ")); err != nil {
+		return fmt.Errorf("commit map: %w", err)
+	}
+	return nil
+}
+
+func (c Client) silentCommand(ctx context.Context, command string) error {
+	response, err := c.command(ctx, command)
+	if err != nil {
+		return err
+	}
+	if message := strings.TrimSpace(response); message != "" {
+		return errors.New(message)
+	}
+	return nil
+}
+
+func (c Client) command(ctx context.Context, command string) (string, error) {
+	if c.SocketPath == "" {
+		return "", errors.New("runtime socket path is empty")
+	}
+	if strings.ContainsAny(command, "\r\n") {
+		return "", errors.New("runtime command contains a newline")
+	}
+
+	timeout := c.Timeout
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	conn, err := (&net.Dialer{Timeout: timeout}).DialContext(ctx, "unix", c.SocketPath)
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	deadline := time.Now().Add(timeout)
+	if contextDeadline, ok := ctx.Deadline(); ok && contextDeadline.Before(deadline) {
+		deadline = contextDeadline
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		return "", err
+	}
+
+	if _, err := io.WriteString(conn, command+"\n"); err != nil {
+		return "", err
+	}
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return "", errors.New("runtime connection is not a UNIX socket")
+	}
+	if err := unixConn.CloseWrite(); err != nil {
+		return "", err
+	}
+
+	response, err := io.ReadAll(io.LimitReader(conn, maxResponseSize+1))
+	if err != nil {
+		return "", err
+	}
+	if len(response) > maxResponseSize {
+		return "", errors.New("runtime response exceeds size limit")
+	}
+	return string(response), nil
+}
+
+func parseVersion(response string) (uint64, error) {
+	const prefix = "New version created:"
+	value, ok := strings.CutPrefix(strings.TrimSpace(response), prefix)
+	if !ok {
+		return 0, fmt.Errorf("unexpected response %q", strings.TrimSpace(response))
+	}
+	version, err := strconv.ParseUint(strings.TrimSpace(value), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid transaction version: %w", err)
+	}
+	return version, nil
+}
+
+func validateToken(name, value string) error {
+	if value == "" {
+		return fmt.Errorf("%s is empty", name)
+	}
+	if strings.Contains(value, "<<") || strings.IndexFunc(value, func(r rune) bool {
+		return r == ';' || unicode.IsSpace(r) || unicode.IsControl(r)
+	}) >= 0 {
+		return fmt.Errorf("%s contains a command delimiter or whitespace", name)
+	}
+	return nil
+}

--- a/internal/haproxyruntime/maps_test.go
+++ b/internal/haproxyruntime/maps_test.go
@@ -1,0 +1,165 @@
+package haproxyruntime
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type fakeRuntime struct {
+	t        *testing.T
+	listener net.Listener
+
+	mu       sync.Mutex
+	commands []string
+	failOn   string
+	wg       sync.WaitGroup
+}
+
+func newFakeRuntime(t *testing.T, failOn string) *fakeRuntime {
+	t.Helper()
+	listener, err := net.Listen("unix", filepath.Join(t.TempDir(), "haproxy.sock"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeRuntime{t: t, listener: listener, failOn: failOn}
+	fake.wg.Add(1)
+	go fake.serve()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		fake.wg.Wait()
+	})
+	return fake
+}
+
+func (f *fakeRuntime) serve() {
+	defer f.wg.Done()
+	for {
+		conn, err := f.listener.Accept()
+		if err != nil {
+			return
+		}
+		f.wg.Add(1)
+		go func() {
+			defer f.wg.Done()
+			defer conn.Close()
+
+			command, err := bufio.NewReader(conn).ReadString('\n')
+			if err != nil {
+				f.t.Errorf("reading command: %v", err)
+				return
+			}
+			command = strings.TrimSpace(command)
+			f.mu.Lock()
+			f.commands = append(f.commands, command)
+			f.mu.Unlock()
+
+			switch {
+			case strings.Contains(command, f.failOn) && f.failOn != "":
+				_, _ = conn.Write([]byte("simulated runtime failure\n"))
+			case strings.HasPrefix(command, "prepare map "):
+				_, _ = conn.Write([]byte("New version created: 17\n"))
+			}
+		}()
+	}
+}
+
+func (f *fakeRuntime) socketPath() string {
+	return f.listener.Addr().String()
+}
+
+func (f *fakeRuntime) received() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.commands...)
+}
+
+func TestReplaceMap(t *testing.T) {
+	fake := newFakeRuntime(t, "")
+	client := Client{SocketPath: fake.socketPath(), Timeout: time.Second}
+
+	err := client.ReplaceMap(context.Background(), "reputation.map", map[string]string{
+		"2001:db8::1": "3",
+		"1.2.3.4":     "1",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"prepare map reputation.map",
+		"add map @17 reputation.map 1.2.3.4 1",
+		"add map @17 reputation.map 2001:db8::1 3",
+		"commit map @17 reputation.map",
+	}
+	if got := fake.received(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("commands = %#v, want %#v", got, want)
+	}
+}
+
+func TestReplaceMapDoesNotCommitFailedTransaction(t *testing.T) {
+	fake := newFakeRuntime(t, "bad-key")
+	client := Client{SocketPath: fake.socketPath(), Timeout: time.Second}
+
+	err := client.ReplaceMap(context.Background(), "reputation.map", map[string]string{
+		"bad-key": "1",
+	})
+	if err == nil || !strings.Contains(err.Error(), "simulated runtime failure") {
+		t.Fatalf("ReplaceMap error = %v", err)
+	}
+
+	for _, command := range fake.received() {
+		if strings.HasPrefix(command, "commit map ") {
+			t.Fatalf("failed transaction was committed: %q", command)
+		}
+	}
+}
+
+func TestReplaceMapRejectsCommandInjection(t *testing.T) {
+	client := Client{SocketPath: "unused"}
+	for _, test := range []struct {
+		name    string
+		mapRef  string
+		entries map[string]string
+	}{
+		{name: "map", mapRef: "bad map", entries: map[string]string{"key": "1"}},
+		{name: "key", mapRef: "map", entries: map[string]string{"key\nshow info": "1"}},
+		{name: "value", mapRef: "map", entries: map[string]string{"key": "1 2"}},
+		{name: "delimiter", mapRef: "map;show info", entries: map[string]string{"key": "1"}},
+		{name: "control", mapRef: "map", entries: map[string]string{"key\x00": "1"}},
+		{name: "payload", mapRef: "map", entries: map[string]string{"<<": "1"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := client.ReplaceMap(context.Background(), test.mapRef, test.entries); err == nil {
+				t.Fatal("ReplaceMap accepted an unsafe token")
+			}
+		})
+	}
+}
+
+func TestReplaceMapRejectsOversizedTransaction(t *testing.T) {
+	entries := make(map[string]string, maxTransactionEntries+1)
+	for i := 0; i <= maxTransactionEntries; i++ {
+		entries[strconv.Itoa(i)] = "1"
+	}
+	client := Client{SocketPath: "unused"}
+	if err := client.ReplaceMap(context.Background(), "map", entries); err == nil {
+		t.Fatal("oversized transaction was accepted")
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	if got, err := parseVersion("\nNew version created: 42\n"); err != nil || got != 42 {
+		t.Fatalf("parseVersion = %d, %v", got, err)
+	}
+	if _, err := parseVersion("permission denied"); err == nil {
+		t.Fatal("parseVersion accepted an error response")
+	}
+}


### PR DESCRIPTION
## What

- Add a bounded HAProxy Runtime API client for atomic map replacement using `prepare map`, transaction-scoped `add map`, and `commit map`.
- Validate all command tokens against whitespace, control characters, semicolons, and payload delimiters.
- Bound response size, per-command time, whole-transaction time, and entry count.
- Test deterministic ordering, failed transactions, injection attempts, and limits with a fake UNIX socket.

## Why

This replaces the omnibus branch’s custom HAProxy peers-protocol sender, which used the wrong tables and had race, expiry, and framing problems. The documented Runtime API is smaller and atomic.

## Validation

- `go test -race ./...`
- `go vet ./...`
- `staticcheck ./...`
- Real HAProxy Runtime API map transaction