### PR TITLE
feat(web): add Web Worker proof of work

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For production use, generate a random `secret` to place in the Berghain configur
 
 ### Proof-of-work difficulty
 
-Each `pow` level can set `difficulty` to the required number of leading zero bits:
+Each `pow` or `pow-worker` level can set `difficulty` to the required number of leading zero bits:
 
 ```yaml
 levels:
@@ -47,6 +47,10 @@ levels:
 ```
 
 The default is `16`; explicit values must be between `1` and `255`. Higher values increase browser work exponentially, so raise the value carefully.
+
+`pow` solves on the main browser thread. `pow-worker` requests the same proof from an inline Web Worker, keeping the
+page responsive and requiring Worker support. The proof is identical on the wire; the server validates it but cannot
+attest that a modified client actually used a Worker.
 
 ## Running with Docker
 

--- a/cmd/spop/config.go
+++ b/cmd/spop/config.go
@@ -85,6 +85,8 @@ func (c LevelConfig) AsLevelConfig() *berghain.LevelConfig {
 		lc.Type = berghain.ValidationTypeNone
 	case "pow":
 		lc.Type = berghain.ValidationTypePOW
+	case "pow-worker":
+		lc.Type = berghain.ValidationTypePOWWorker
 	default:
 		Fatal("unknown validation type", "validator", c.Type)
 	}

--- a/cmd/spop/config.yaml
+++ b/cmd/spop/config.yaml
@@ -22,6 +22,6 @@ frontend:
         # Leading zero bits required from the proof. Default: 16; range: 1-255.
         difficulty: 16
       - duration: 10s
-        type: pow
+        type: pow-worker
         countdown: 0
         difficulty: 22

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -1,6 +1,11 @@
 global
     log stdout format raw local0
 
+    # The default single-file build includes an inline POW Worker and exceeds
+    # HAProxy's 16 KiB default buffer. Keep enough room for the response and
+    # headers served by the http-request return rules below.
+    tune.bufsize 32768
+
 defaults
     mode http
     log global

--- a/validator_pow.go
+++ b/validator_pow.go
@@ -28,6 +28,7 @@ func releaseSHA256(h hash.Hash) {
 }
 
 type powValidator struct {
+	template string
 }
 
 const (
@@ -42,20 +43,22 @@ const (
 
 const hexdigits = "0123456789abcdef"
 
-var validatorPOWChallengeTemplate = mustJSONEncodeString(struct {
-	Countdown  int    `json:"c"`
-	Type       int    `json:"t"`
-	Difficulty string `json:"d"`
-	Random     string `json:"r"`
-	Hash       string `json:"s"`
-}{
-	// Only strings have to be set, as the default is zero for ints.
-	// We do set the Type here because it is static anyway...
-	Type:       1,
-	Difficulty: "00",
-	Random:     validatorPOWRandom,
-	Hash:       validatorPOWHash,
-})
+func powChallengeTemplate(challengeType int) string {
+	return mustJSONEncodeString(struct {
+		Countdown  int    `json:"c"`
+		Type       int    `json:"t"`
+		Difficulty string `json:"d"`
+		Random     string `json:"r"`
+		Hash       string `json:"s"`
+	}{
+		Type:       challengeType,
+		Difficulty: "00",
+		Random:     validatorPOWRandom,
+		Hash:       validatorPOWHash,
+	})
+}
+
+var validatorPOWChallengeTemplate = powChallengeTemplate(1)
 
 // This prevents invalid template strings by validatoring them on start
 var _ = func() bool {
@@ -66,7 +69,7 @@ var _ = func() bool {
 	return true
 }()
 
-func (powValidator) onNew(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
+func (p powValidator) onNew(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
 	h := b.acquireHMAC()
 	defer b.releaseHMAC(h)
 
@@ -76,7 +79,7 @@ func (powValidator) onNew(b *Berghain, req *ValidatorRequest, resp *ValidatorRes
 		return err
 	}
 
-	copy(resp.Body.WriteBytes(), validatorPOWChallengeTemplate)
+	copy(resp.Body.WriteBytes(), p.template)
 
 	resp.Body.AdvanceW(len(`{"c":`))
 	// the following conversion is faster than sprintf but also way uglier, I am sorry.
@@ -212,8 +215,10 @@ func hasLeadingZeroBits(b []byte, bits int) bool {
 var errInvalidSolution = fmt.Errorf("invalid solution")
 
 func validatorPOW(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
-	var p powValidator
+	return powValidator{template: validatorPOWChallengeTemplate}.run(b, req, resp)
+}
 
+func (p powValidator) run(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
 	switch req.Method {
 	case http.MethodPost:
 		if err := p.isValid(b, req, resp); err != nil {

--- a/validator_pow_test.go
+++ b/validator_pow_test.go
@@ -33,7 +33,7 @@ func solvePOW(tb testing.TB, b []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	if p.T != 1 {
+	if p.T != 1 && p.T != 2 {
 		return nil, fmt.Errorf("invalid challenge type: %d", p.T)
 	}
 

--- a/validator_pow_worker.go
+++ b/validator_pow_worker.go
@@ -1,0 +1,11 @@
+package berghain
+
+var validatorPOWWorkerChallengeTemplate = powChallengeTemplate(2)
+
+// validatorPOWWorker asks the browser to solve the same POW inside a Web
+// Worker. The proof is intentionally identical, so the server validates both
+// variants through the same implementation and does not claim worker
+// attestation.
+func validatorPOWWorker(b *Berghain, req *ValidatorRequest, resp *ValidatorResponse) error {
+	return powValidator{template: validatorPOWWorkerChallengeTemplate}.run(b, req, resp)
+}

--- a/validator_pow_worker_test.go
+++ b/validator_pow_worker_test.go
@@ -1,0 +1,60 @@
+package berghain
+
+import (
+	"net/http"
+	"net/netip"
+	"testing"
+	"time"
+)
+
+func TestValidatorPOWWorker(t *testing.T) {
+	bh := NewBerghain(generateSecret(t))
+	bh.Levels = []*LevelConfig{{
+		Duration:   time.Minute,
+		Type:       ValidationTypePOWWorker,
+		Difficulty: 8,
+	}}
+
+	req, resp := AcquireValidatorRequest(), AcquireValidatorResponse()
+	defer ReleaseValidatorRequest(req)
+	defer ReleaseValidatorResponse(resp)
+
+	req.Identifier = &RequestIdentifier{
+		SrcAddr: netip.MustParseAddr("1.2.3.4"),
+		Host:    []byte("example.com"),
+		Level:   1,
+	}
+	req.Method = http.MethodGet
+
+	if err := ValidationTypePOWWorker.RunValidator(bh, req, resp); err != nil {
+		t.Fatalf("creating worker challenge: %v", err)
+	}
+
+	challenge, err := decodePOWChallenge(resp.Body.ReadBytes())
+	if err != nil {
+		t.Fatalf("decoding worker challenge: %v", err)
+	}
+	if challenge.T != 2 {
+		t.Errorf("challenge type = %d, want 2", challenge.T)
+	}
+	if challenge.D != "08" {
+		t.Errorf("challenge difficulty = %q, want %q", challenge.D, "08")
+	}
+	if resp.Body.Len() != len(validatorPOWWorkerChallengeTemplate) {
+		t.Errorf("challenge response length = %d, want %d", resp.Body.Len(), len(validatorPOWWorkerChallengeTemplate))
+	}
+
+	solution, err := solvePOW(t, resp.Body.ReadBytes())
+	if err != nil {
+		t.Fatalf("solving worker challenge: %v", err)
+	}
+
+	req.Method = http.MethodPost
+	req.Body = solution
+	if err := ValidationTypePOWWorker.RunValidator(bh, req, resp); err != nil {
+		t.Fatalf("validating worker challenge: %v", err)
+	}
+	if err := bh.IsValidCookie(*req.Identifier, resp.Token.ReadBytes()); err != nil {
+		t.Errorf("validating issued cookie: %v", err)
+	}
+}

--- a/validators.go
+++ b/validators.go
@@ -15,6 +15,7 @@ const (
 	_ ValidationType = iota
 	ValidationTypeNone
 	ValidationTypePOW
+	ValidationTypePOWWorker
 )
 
 type ValidatorResponse struct {
@@ -70,6 +71,8 @@ func (v ValidationType) RunValidator(b *Berghain, req *ValidatorRequest, resp *V
 		return validatorNone(b, req, resp)
 	case ValidationTypePOW:
 		return validatorPOW(b, req, resp)
+	case ValidationTypePOWWorker:
+		return validatorPOWWorker(b, req, resp)
 	default:
 		return errors.New("unknown validation type")
 	}

--- a/web/src/challange/challanges.js
+++ b/web/src/challange/challanges.js
@@ -2,28 +2,18 @@
  * Collection of challenges.
  */
 
-import {doHash, hasLeadingZeroBits, parsePOWDifficulty, powInput} from "./pow.js";
+import {solvePOWNonce} from "./pow.js";
 
 /**
- * Challenge POW.
+ * Submit a solved POW nonce.
  *
  * @param {object} challenge
+ * @param {number} nonce
  * @return {Promise<void>}
  */
-async function challengePOW(challenge){
-    const difficulty = parsePOWDifficulty(challenge.d);
-    let i;
-
-    // eslint-disable-next-line no-constant-condition
-    for (i = 0; true; i++){
-        const hash = await doHash(powInput(challenge, i));
-        if (hasLeadingZeroBits(hash, difficulty)){
-            break;
-        }
-    }
-
+async function submitPOWSolution(challenge, nonce){
     const response = await fetch("/cdn-cgi/challenge-platform/challenge", {
-        body: challenge.r + "-" + challenge.s + "-" + i.toString(),
+        body: challenge.r + "-" + challenge.s + "-" + nonce.toString(),
         headers: {
             "Content-Type": "text/plain",
         },
@@ -32,6 +22,69 @@ async function challengePOW(challenge){
     if (!response.ok){
         throw new Error(`Challenge submission failed (${response.status})`);
     }
+}
+
+/**
+ * Challenge POW.
+ *
+ * @param {object} challenge
+ * @return {Promise<void>}
+ */
+async function challengePOW(challenge){
+    const nonce = await solvePOWNonce(challenge);
+    await submitPOWSolution(challenge, nonce);
+}
+
+/**
+ * Run a POW Worker and return its validated response. The Worker constructor
+ * is injected so orchestration and failure handling can be tested in Node.
+ *
+ * @param {object} challenge
+ * @param {new () => Worker} WorkerConstructor
+ * @return {Promise<number>}
+ */
+export async function solvePOWWithWorker(challenge, WorkerConstructor){
+    const worker = new WorkerConstructor();
+
+    try {
+        return await new Promise((resolve, reject) => {
+            worker.onmessage = (event) => {
+                const result = event.data;
+                if (typeof result?.error === "string"){
+                    reject(new Error(`POW worker failed: ${result.error}`));
+                    return;
+                }
+                if (!Number.isSafeInteger(result?.nonce) || result.nonce < 0){
+                    reject(new Error("POW worker returned an invalid nonce"));
+                    return;
+                }
+                resolve(result.nonce);
+            };
+            worker.onerror = (event) => {
+                const detail = typeof event?.message === "string" ? `: ${event.message}` : "";
+                reject(new Error(`POW worker failed${detail}`));
+            };
+            worker.onmessageerror = () => reject(new Error("POW worker returned an unreadable message"));
+            worker.postMessage(challenge);
+        });
+    }
+    finally {
+        worker.terminate();
+    }
+}
+
+/**
+ * Challenge POW inside an inline Web Worker. Vite's Worker module is loaded
+ * only when the server explicitly selects challenge type 2.
+ *
+ * @param {object} challenge
+ * @return {Promise<void>}
+ */
+async function challengePOWWorker(challenge){
+    const workerModule = await import("./powWorker.js?worker&inline");
+    const PowWorker = workerModule.default;
+    const nonce = await solvePOWWithWorker(challenge, PowWorker);
+    await submitPOWSolution(challenge, nonce);
 }
 
 /**
@@ -51,6 +104,8 @@ export function getChallengeSolver(challengeType){
             return ["Please wait...", challengeNone];
         case 1:
             return ["Solving POW challenge...", challengePOW];
+        case 2:
+            return ["Solving POW challenge in a Worker...", challengePOWWorker];
         default:
             throw new Error(`Unknown challenge type: ${challengeType}`);
     }

--- a/web/src/challange/pow.js
+++ b/web/src/challange/pow.js
@@ -78,3 +78,23 @@ export function hasLeadingZeroBits(bytes, bits){
     const remainingBits = bits % 8;
     return remainingBits === 0 || (bytes[wholeBytes] >> (8 - remainingBits)) === 0;
 }
+
+/**
+ * Find a nonce satisfying a challenge. This is shared by the main-thread and
+ * Worker solvers so both produce the exact wire proof the server validates.
+ *
+ * @param {{d?: string, r: string, s: string}} challenge
+ * @return {Promise<number>}
+ */
+export async function solvePOWNonce(challenge){
+    const difficulty = parsePOWDifficulty(challenge.d);
+
+    for (let nonce = 0; nonce <= Number.MAX_SAFE_INTEGER; nonce++){
+        const hash = await doHash(powInput(challenge, nonce));
+        if (hasLeadingZeroBits(hash, difficulty)){
+            return nonce;
+        }
+    }
+
+    throw new Error("POW nonce space exhausted");
+}

--- a/web/src/challange/pow.test.js
+++ b/web/src/challange/pow.test.js
@@ -1,13 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import {getChallengeSolver} from "./challanges.js";
+import {getChallengeSolver, solvePOWWithWorker} from "./challanges.js";
 import {
     defaultPOWDifficulty,
     doHash,
     hasLeadingZeroBits,
     parsePOWDifficulty,
     powInput,
+    solvePOWNonce,
 } from "./pow.js";
 
 test("difficulty defaults to the historic target", () => {
@@ -51,4 +52,62 @@ test("a non-successful solution submission rejects", async(t) => {
 test("hashing produces a SHA-256 digest", async() => {
     const digest = await doHash("proof");
     assert.equal(digest.length, 32);
+});
+
+test("main-thread nonce solver uses the signed POW input", async() => {
+    const challenge = {d: "04", r: "timestamp", s: "signature"};
+    const nonce = await solvePOWNonce(challenge);
+    const digest = await doHash(powInput(challenge, nonce));
+    assert.equal(hasLeadingZeroBits(digest, 4), true);
+});
+
+test("worker solver sends the complete challenge and terminates", async() => {
+    let instance;
+
+    class FakeWorker {
+        constructor(){
+            instance = this;
+            this.terminated = false;
+        }
+
+        postMessage(challenge){
+            this.challenge = challenge;
+            queueMicrotask(() => this.onmessage({data: {nonce: 7}}));
+        }
+
+        terminate(){
+            this.terminated = true;
+        }
+    }
+
+    const challenge = {d: "04", r: "timestamp", s: "signed-value"};
+    assert.equal(await solvePOWWithWorker(challenge, FakeWorker), 7);
+    assert.deepEqual(instance.challenge, challenge);
+    assert.equal(instance.terminated, true);
+    assert.match(getChallengeSolver(2)[0], /Worker/u);
+});
+
+test("worker solver propagates errors and terminates", async() => {
+    let instance;
+
+    class FakeWorker {
+        constructor(){
+            instance = this;
+            this.terminated = false;
+        }
+
+        postMessage(){
+            queueMicrotask(() => this.onmessage({data: {error: "hashing unavailable"}}));
+        }
+
+        terminate(){
+            this.terminated = true;
+        }
+    }
+
+    await assert.rejects(
+        solvePOWWithWorker({d: "04", r: "timestamp", s: "signature"}, FakeWorker),
+        /POW worker failed: hashing unavailable/u,
+    );
+    assert.equal(instance.terminated, true);
 });

--- a/web/src/challange/powWorker.js
+++ b/web/src/challange/powWorker.js
@@ -1,0 +1,16 @@
+/**
+ * Inline Web Worker entry point for the pow-worker challenge type.
+ */
+
+import {solvePOWNonce} from "./pow.js";
+
+self.onmessage = async(event) => {
+    try {
+        const nonce = await solvePOWNonce(event.data);
+        self.postMessage({nonce});
+    }
+    catch (error){
+        const message = error instanceof Error ? error.message : "Unknown POW worker error";
+        self.postMessage({error: message});
+    }
+};


### PR DESCRIPTION
> Stacked on #62; this PR contains only the Worker challenge delta.

## What

- Add the `pow-worker` validation type with the same server-authoritative proof format as regular POW.
- Lazily construct an inline Vite Worker only for type 2 challenges.
- Share nonce solving, validate Worker responses, propagate failures, and always terminate the Worker.
- Raise the example HAProxy buffer to 32 KiB for the 20,349-byte single-file bundle.

## Why

The omnibus Worker hashed a different input than the hardened server proof, swallowed submission failures, and loaded Worker code eagerly. The server intentionally validates the proof without claiming it can attest that a modified client used a Worker.

## Validation

- `go test -race ./...` and `go vet ./...`
- `staticcheck ./...`
- Nine Node tests, ESLint, and both Vite builds
- HAProxy 3.3 configuration validation
- Live HAProxy/SPOP response test confirmed the complete bundle is served