### PR TITLE
feat: pseudonymize source addresses in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ For Debian / Ubuntu: apt install npm
 
 For production use, generate a random `secret` to place in the Berghain configuration file using `openssl rand -base64 32`.
 
+## Log privacy
+
+The Go SPOE agent writes a 128-bit HMAC source identifier instead of a plaintext client IP address.
+It is stable until the configured `secret` changes and uses a key derived separately from cookie
+authentication. The example HAProxy access log likewise replaces `%ci` with a 256-bit SHA-2
+pseudonym keyed by `BERGHAIN_SOURCE_LOG_KEY`. Set that environment variable to an independent,
+high-entropy production secret; the checked-in value is only a local-development fallback.
+
+These identifiers are pseudonymous personal data, not anonymous values. An operator with the
+relevant secret can test candidate addresses, particularly across the IPv4 address space.
+Hostnames, request paths, and client-provided support IDs can also appear in logs.
+
 ## Running with Docker
 
 To run the project using Docker, follow these steps:

--- a/berghain.go
+++ b/berghain.go
@@ -3,8 +3,10 @@ package berghain
 import (
 	"crypto/hmac"
 	"crypto/sha256"
+	"encoding/hex"
 	"hash"
 	"log/slog"
+	"net/netip"
 	"sync"
 	"time"
 )
@@ -19,18 +21,30 @@ type Berghain struct {
 	Levels         []*LevelConfig
 	TrustedDomains []string
 
-	secret []byte
-	hmac   sync.Pool
+	secret        []byte
+	hmac          sync.Pool
+	sourceLogHMAC sync.Pool
 }
 
 var hashAlgo = sha256.New
 
+const sourceLogPurpose = "berghain/source-log/v1"
+
 func NewBerghain(secret []byte) *Berghain {
+	keyDeriver := hmac.New(hashAlgo, secret)
+	_, _ = keyDeriver.Write([]byte(sourceLogPurpose))
+	sourceLogKey := keyDeriver.Sum(nil)
+
 	return &Berghain{
 		secret: secret,
 		hmac: sync.Pool{
 			New: func() any {
 				return NewZeroHasher(hmac.New(hashAlgo, secret))
+			},
+		},
+		sourceLogHMAC: sync.Pool{
+			New: func() any {
+				return hmac.New(hashAlgo, sourceLogKey)
 			},
 		},
 	}
@@ -43,6 +57,37 @@ func (b *Berghain) acquireHMAC() hash.Hash {
 func (b *Berghain) releaseHMAC(h hash.Hash) {
 	h.Reset()
 	b.hmac.Put(h)
+}
+
+// SourceLogID returns a stable keyed pseudonym for an address. It prevents
+// accidental plaintext IP logging, but it is not anonymization: a holder of the
+// configuration secret can enumerate the IPv4 address space.
+func (b *Berghain) SourceLogID(address netip.Addr) string {
+	if !address.IsValid() {
+		return ""
+	}
+
+	h := b.sourceLogHMAC.Get().(hash.Hash)
+	defer func() {
+		h.Reset()
+		b.sourceLogHMAC.Put(h)
+	}()
+
+	var raw [16]byte
+	if address.Is4() {
+		value := address.As4()
+		copy(raw[:], value[:])
+		_, _ = h.Write(raw[:4])
+	} else {
+		value := address.As16()
+		copy(raw[:], value[:])
+		_, _ = h.Write(raw[:])
+	}
+
+	digest := h.Sum(nil)
+	var encoded [32]byte
+	hex.Encode(encoded[:], digest[:16])
+	return string(encoded[:])
 }
 
 func (b *Berghain) LevelConfig(level uint8) *LevelConfig {

--- a/berghain_test.go
+++ b/berghain_test.go
@@ -17,6 +17,32 @@ func generateSecret(tb testing.TB) []byte {
 	return b
 }
 
+func TestSourceLogID(t *testing.T) {
+	secret := generateSecret(t)
+	bh := NewBerghain(secret)
+	address := netip.MustParseAddr("192.0.2.1")
+
+	got := bh.SourceLogID(address)
+	if got != bh.SourceLogID(address) {
+		t.Fatal("SourceLogID is not deterministic")
+	}
+	if len(got) != 32 {
+		t.Fatalf("SourceLogID length = %d, want 32", len(got))
+	}
+	if got == address.String() {
+		t.Fatal("SourceLogID returned the plaintext address")
+	}
+	if got == bh.SourceLogID(netip.MustParseAddr("192.0.2.2")) {
+		t.Fatal("SourceLogID collided for distinct addresses")
+	}
+	if got == NewBerghain(generateSecret(t)).SourceLogID(address) {
+		t.Fatal("SourceLogID does not depend on the secret")
+	}
+	if invalid := bh.SourceLogID(netip.Addr{}); invalid != "" {
+		t.Fatalf("SourceLogID(invalid) = %q, want empty", invalid)
+	}
+}
+
 func TestBerghain(t *testing.T) {
 	bh := NewBerghain(generateSecret(t))
 	bh.Levels = []*LevelConfig{

--- a/cmd/spop/frontend.go
+++ b/cmd/spop/frontend.go
@@ -122,7 +122,7 @@ func (f *frontend) HandleSPOEValidate(ctx context.Context, w *encoding.ActionWri
 		slog.ErrorContext(ctx, "cant read netip.Address from message")
 		return
 	}
-	ctx = context.WithValue(ctx, "src", addr.String())
+	ctx = context.WithValue(ctx, "src", f.bh.SourceLogID(addr))
 	ri.SrcAddr = addr
 
 	if err := readExpectedKVEntry(ctx, m, k, "host"); err != nil {
@@ -171,6 +171,7 @@ func (f *frontend) HandleSPOEChallenge(ctx context.Context, w *encoding.ActionWr
 		return
 	}
 	ri.Level = uint8(k.ValueInt())
+	ctx = context.WithValue(ctx, "level", int(ri.Level))
 	if ri.Level == 0 {
 		// berghain is disabled, just exit early and ignore everything...
 		return
@@ -183,7 +184,9 @@ func (f *frontend) HandleSPOEChallenge(ctx context.Context, w *encoding.ActionWr
 	addr, ok := netip.AddrFromSlice(k.ValueBytes())
 	if !ok {
 		slog.ErrorContext(ctx, "cant read netip.Address from message")
+		return
 	}
+	ctx = context.WithValue(ctx, "src", f.bh.SourceLogID(addr))
 	ri.SrcAddr = addr
 
 	if err := readExpectedKVEntry(ctx, m, k, "host"); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ version: '3.8'
 services:
   berghain-haproxy:
     build: .
+    environment:
+      BERGHAIN_SOURCE_LOG_KEY: ${BERGHAIN_SOURCE_LOG_KEY:-berghain-development-source-log-key}
     ports:
       - "8080:8080" # Expose the backend service
     volumes:

--- a/docs/index.html
+++ b/docs/index.html
@@ -108,16 +108,18 @@
           change, the cookie no longer validates &mdash; and that is the whole mechanism.</p>
       </div>
       <div class="card">
-        <h3>No server-side store</h3>
-        <p>Because verification is stateless, there is no database of visitors, sessions or
-          fingerprints to query, leak or subpoena. The server only re-computes the signature and
-          compares it. Nothing about your visit is retained after the cookie expires.</p>
+        <h3>No verification database</h3>
+        <p>Verification is stateless: there is no Berghain database of visitors, sessions or
+          fingerprints. The server only re-computes the cookie signature and compares it. Normal
+          proxy and application logs may still be retained according to the site operator&#39;s
+          logging policy.</p>
       </div>
       <div class="card">
         <h3>Your IP is bound, not stored</h3>
         <p>Your IP address is mixed into the cookie&#39;s signature so a clearance cannot be copied to
-          another machine. It is <strong>bound cryptographically, not saved in plaintext</strong> as a
-          record of where you were.</p>
+          another machine. The Berghain agent and example proxy log keyed pseudonymous identifiers
+          instead of the plaintext address. This supports log correlation but is not anonymization;
+          other infrastructure may have its own access logs.</p>
       </div>
       <div class="card">
         <h3>No third-party CDN</h3>

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -1,5 +1,7 @@
 global
     log stdout format raw local0
+    # Development fallback only. Set a high-entropy BERGHAIN_SOURCE_LOG_KEY in production.
+    set-var proc.source_log_key str("${BERGHAIN_SOURCE_LOG_KEY-berghain-development-source-log-key}")
 
 defaults
     mode http
@@ -17,7 +19,8 @@ listen stats
 
 frontend test
     bind *:8080
-    log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %ID spoa-error:\ %[var(txn.berghain.error)]"
+    http-request set-var(txn.source_log_id) src,concat(:,proc.source_log_key),sha2(256),hex
+    log-format "%[var(txn.source_log_id)]\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %ID spoa-error:\ %[var(txn.berghain.error)]"
 
     acl berghain_path path /cdn-cgi/challenge-platform/challenge
 


### PR DESCRIPTION
> Stacked on #63 so the privacy documentation can accurately describe support IDs.

## What

- Replace plaintext source addresses in Go agent logs with a 128-bit, domain-separated HMAC pseudonym.
- Replace `%ci` in the example HAProxy log with a separately keyed 256-bit SHA-2 pseudonym.
- Add the `BERGHAIN_SOURCE_LOG_KEY` Compose setting and document production key requirements and retention limits.
- Correct the help page’s previous claim that nothing can survive cookie expiry.

## Why

The omnibus branch reused the cookie HMAC and called low-entropy IP hashing irreversible. These values are pseudonymous, not anonymous: an operator with the key can enumerate IPv4 candidates, and ordinary infrastructure logs remain subject to operator retention.

## Validation

- `go test -race ./...`, `go vet ./...`, and `staticcheck ./...`
- Both frontend builds and HAProxy config validation
- Live access-log test matched the keyed pseudonym and found no plaintext source address
- Full Compose privacy-log validation