### PR TITLE
feat(haproxy): ban repeated challenge attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,5 +65,10 @@ The example HAProxy frontend applies two admission controls before it invokes Be
 These values are examples rather than universal production defaults. Tune them for the expected
 traffic profile and capacity of the protected service.
 
+The example also tracks challenge submissions in a separate one-minute window. More than ten
+submissions sets a flat ten-minute ban in HAProxy. Banned browser requests receive the normal
+challenge shell with HTTP `429`; the shell displays the remaining duration and reloads when it
+expires. This local example does not implement escalating ban durations.
+
 ## Attributions
 Thanks to [@NullDev](https://github.com/NullDev) and [@arellak](https://github.com/arellak), as they did most of the frontend work.

--- a/docs/index.html
+++ b/docs/index.html
@@ -377,7 +377,9 @@
         <summary>Rate limiting</summary>
         <div class="body">
           <p>Operators commonly add request rate limits in HAProxy so that even verified clients
-            cannot flood an endpoint. Limits and thresholds are set per deployment.</p>
+            cannot flood an endpoint. The example also applies a flat, expiring ban after too many
+            challenge submissions; the verification screen shows the remaining time. Limits and
+            thresholds are set per deployment.</p>
         </div>
       </details>
     </div>

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -30,6 +30,24 @@ frontend test
     http-request track-sc0 src table st_burst if !berghain_path
     http-request return status 429 content-type "application/json" string '{"error":"rate_limited"}' hdr "Retry-After" "1" if !berghain_path { sc0_http_req_rate(st_burst) gt 30 }
 
+    # Read the ban table before tracking a new challenge attempt. Banned requests
+    # therefore do not refresh their own expiry and the remaining time ticks down.
+    acl is_banned src,table_gpt0(st_challenge) -m int gt 0
+    http-request set-var(txn.ban_remaining) src,table_expire(st_challenge),div(1000) if is_banned
+
+    # Serve the regular challenge shell for browser requests. Its API request
+    # receives the JSON response below and renders the remaining time live.
+    acl is_ssl ssl_fc
+    http-request return status 429 content-type "text/html" file "web/dist/default/index.html" hdr "Retry-After" "%[var(txn.ban_remaining)]" if is_banned !berghain_path !is_ssl
+    http-request return status 429 content-type "text/html" file "web/dist/native-crypto/index.html" hdr "Retry-After" "%[var(txn.ban_remaining)]" if is_banned !berghain_path is_ssl
+    http-request return status 429 content-type "application/json" lf-string '{"t":3,"remaining":%[var(txn.ban_remaining)]}' hdr "Retry-After" "%[var(txn.ban_remaining)]" if is_banned berghain_path
+
+    # sc2 is reserved for challenge submissions. Crossing the one-minute
+    # threshold sets a flat ban flag whose lifetime is bounded by table expiry.
+    http-request track-sc2 src table st_challenge if berghain_path METH_POST
+    acl too_many_challenges sc2_http_req_rate(st_challenge) gt 10
+    http-request sc-set-gpt0(2) 1 if too_many_challenges
+
     http-request track-sc1 src table st_src
 
     filter spoe engine berghain config examples/haproxy/berghain.cfg
@@ -44,8 +62,6 @@ frontend test
     http-request return status 501 if { var(txn.berghain.error) -m found }
 
     acl berghain_valid var(txn.berghain.valid) -m bool
-    acl is_ssl ssl_fc
-
     http-request return status 403 content-type "text/html" file "web/dist/default/index.html" if !berghain_valid !berghain_path berghain_active !is_ssl
     http-request return status 403 content-type "text/html" file "web/dist/native-crypto/index.html" if !berghain_valid !berghain_path berghain_active is_ssl
     http-request wait-for-body time 5s if berghain_path METH_POST
@@ -58,6 +74,9 @@ backend st_src
 
 backend st_burst
     stick-table type ipv6 size 1m expire 1m store http_req_rate(1s)
+
+backend st_challenge
+    stick-table type ipv6 size 1m expire 10m store http_req_rate(1m),gpt0
 
 backend app_backend
     mode http

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "build:native-crypto": "vite build --mode native-crypto",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
+    "test": "node --test",
     "preview": "vite preview"
   },
   "devDependencies": {

--- a/web/src/challange/challanger.js
+++ b/web/src/challange/challanger.js
@@ -1,6 +1,8 @@
 import {getChallengeSolver} from "./challanges";
 import * as loader from "./loader.js";
 
+const CHALLENGE_TYPE_BANNED = 3;
+
 /**
  * Decide and solve browser challenges.
  */
@@ -30,6 +32,12 @@ export async function doChallenge(){
 
         const challenge = await getChallenge();
         const {t} = challenge;
+
+        if (t === CHALLENGE_TYPE_BANNED){
+            loader.banCountdown(challenge.remaining);
+            return;
+        }
+
         countdown = challenge.c;
 
         const [name, solver] = getChallengeSolver(t);

--- a/web/src/challange/loader.js
+++ b/web/src/challange/loader.js
@@ -67,3 +67,62 @@ export function stop(countdown, failed = false){
         }
     }, 1000);
 }
+
+/**
+ * Format a duration in seconds as "Dd HH:MM:SS" (days omitted when zero).
+ *
+ * @param {number} totalSeconds
+ * @return {string}
+ */
+export function formatDuration(totalSeconds){
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const pad = (value) => value.toString().padStart(2, "0");
+
+    if (days > 0){
+        return `${days}d ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    }
+    return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+/**
+ * Render HAProxy's remaining flat-ban duration and reload when it expires.
+ *
+ * @param {number} remainingSeconds
+ */
+export function banCountdown(remainingSeconds){
+    const loader = /** @type {HTMLDivElement} */ (document.querySelector(".circle-loader"));
+    const container = /** @type {HTMLDivElement} */ (document.querySelector(".captcha-container"));
+    if (loader){
+        loader.style.visibility = "hidden";
+    }
+    if (container){
+        container.classList.remove("alert-warning");
+        container.classList.add("alert-danger");
+    }
+
+    let remaining = Math.max(0, Math.floor(Number(remainingSeconds) || 0));
+    const render = () => {
+        if (remaining <= 0){
+            setChallengeInfo("Block expired. Reloading ...");
+            window.location.reload();
+            return;
+        }
+        setChallengeInfo(`Too many verification attempts. Try again in ${formatDuration(remaining)}.`);
+    };
+
+    render();
+    if (remaining <= 0){
+        return;
+    }
+
+    const interval = setInterval(() => {
+        remaining--;
+        if (remaining <= 0){
+            clearInterval(interval);
+        }
+        render();
+    }, 1000);
+}

--- a/web/test/loader.test.js
+++ b/web/test/loader.test.js
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {formatDuration} from "../src/challange/loader.js";
+
+test("formats ban durations", () => {
+    assert.equal(formatDuration(0), "00:00:00");
+    assert.equal(formatDuration(65), "00:01:05");
+    assert.equal(formatDuration(3661), "01:01:01");
+    assert.equal(formatDuration(90061), "1d 01:01:01");
+});


### PR DESCRIPTION
> Stacked on #65; this PR adds only challenge-attempt enforcement and its browser state.

## What

- Track challenge submissions in a dedicated one-minute window.
- Set a flat ten-minute HAProxy ban after more than ten submissions without letting banned requests refresh expiry.
- Serve the normal challenge shell with HTTP 429 and return a type 3 JSON state with remaining seconds.
- Render a live duration countdown and reload when the ban expires.

## Why

The original rules mixed counters and claimed escalating bans they did not implement. This example is deliberately a bounded, flat local ban and documents that limitation.

## Validation

- Node duration tests, ESLint, and both Vite builds
- HAProxy 3.3 configuration validation
- Live HAProxy/SPOP test returned `429 {"t":3,"remaining":599}` and the 429 challenge shell