### PR TITLE
feat(haproxy): apply live reputation policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,21 @@ RUN npm run build
 FROM golang:1.24 AS backend-builder
 WORKDIR /app
 COPY . .
-RUN go build -o berghain ./cmd/spop
+RUN go build -o berghain ./cmd/spop \
+    && go build -o feedupdater ./cmd/feedupdater
 
 # Stage 3: Final image
 FROM haproxy:lts-bookworm
 WORKDIR /app
 COPY --from=frontend-builder /app/web/dist ./web/dist
 COPY --from=backend-builder /app/berghain ./berghain
+COPY --from=backend-builder /app/feedupdater ./feedupdater
+RUN mkdir -p ./examples/haproxy/state
+COPY examples/haproxy/berghain.cfg ./examples/haproxy/berghain.cfg
+COPY examples/haproxy/entrypoint.sh ./examples/haproxy/entrypoint.sh
+COPY examples/haproxy/maps ./examples/haproxy/maps
+COPY --chown=haproxy:haproxy examples/haproxy/state/reputation.map ./examples/haproxy/state/reputation.map
 COPY examples/haproxy/haproxy.cfg ./haproxy.cfg
 COPY cmd/spop/config.yaml ./config.yaml
 
-CMD ["sh", "-c", "haproxy -f haproxy.cfg & ./berghain -config config.yaml"]
+CMD ["sh", "examples/haproxy/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ traffic through Cloudflare.
 
 ```sh
 # Write a persistent map file once.
-go run ./cmd/feedupdater -map-file examples/haproxy/maps/reputation.map
+go run ./cmd/feedupdater -map-file examples/haproxy/state/reputation.map
 
 # Also update the same map atomically in a running HAProxy process.
 go run ./cmd/feedupdater \
-  -map-file examples/haproxy/maps/reputation.map \
+  -map-file examples/haproxy/state/reputation.map \
   -runtime-socket /tmp/haproxy-admin.sock \
   -interval 6h
 ```
@@ -78,6 +78,13 @@ If any enabled remote source fails, is oversized, is empty, or contains malforme
 is rejected before the existing map is replaced. Live transactions require HAProxy 2.4 or newer;
 when `-runtime-map` is set, its value must exactly match the map identifier in HAProxy's loaded
 configuration.
+
+The example HAProxy policy interprets map action `1` as a silent drop and action `3` as challenge
+level 3. It refreshes the map every six hours in the container. Add lower-case, exact hostnames to
+`examples/haproxy/maps/bypass-hosts.lst` only when a hostname must bypass both reputation and rate
+policies. Ports are removed before matching; hostname suffixes such as `.onion` and `.i2p` are never
+trusted implicitly. Docker Compose persists the generated reputation state in its
+`reputation-data` volume and mounts the operator-edited bypass list read-only.
 
 ## Attributions
 Thanks to [@NullDev](https://github.com/NullDev) and [@arellak](https://github.com/arellak), as they did most of the frontend work.

--- a/cmd/feedupdater/main.go
+++ b/cmd/feedupdater/main.go
@@ -523,7 +523,7 @@ func main() {
 		cloudActionName string
 		interval        time.Duration
 	)
-	flag.StringVar(&mapFile, "map-file", "examples/haproxy/maps/reputation.map", "persistent HAProxy reputation map")
+	flag.StringVar(&mapFile, "map-file", "examples/haproxy/state/reputation.map", "persistent HAProxy reputation map")
 	flag.StringVar(&runtimeSocket, "runtime-socket", "", "optional HAProxy Runtime API UNIX socket")
 	flag.StringVar(&runtimeMap, "runtime-map", "", "map path as registered in HAProxy (defaults to -map-file)")
 	flag.StringVar(&banlist, "banlist", "", "optional local file of IPs to block")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   berghain-haproxy:
     build: .
@@ -8,5 +6,9 @@ services:
     volumes:
       - ./examples/haproxy/haproxy.cfg:/app/haproxy.cfg
       - ./examples/haproxy/berghain.cfg:/app/examples/haproxy/berghain.cfg
+      - ./examples/haproxy/maps/bypass-hosts.lst:/app/examples/haproxy/maps/bypass-hosts.lst:ro
+      - reputation-data:/app/examples/haproxy/state
       - ./cmd/spop/config.yaml:/app/config.yaml
-    command: sh -c "haproxy -f haproxy.cfg & ./berghain -config config.yaml"
+
+volumes:
+  reputation-data:

--- a/examples/haproxy/entrypoint.sh
+++ b/examples/haproxy/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+./berghain -config config.yaml &
+
+(
+    attempts=0
+    while [ ! -S /tmp/haproxy-admin.sock ]; do
+        attempts=$((attempts + 1))
+        if [ "$attempts" -ge 100 ]; then
+            echo "HAProxy Runtime API socket did not become ready" >&2
+            exit 1
+        fi
+        sleep 0.1
+    done
+
+    exec ./feedupdater \
+        -map-file examples/haproxy/state/reputation.map \
+        -runtime-socket /tmp/haproxy-admin.sock \
+        -runtime-map examples/haproxy/state/reputation.map \
+        -interval 6h
+) &
+
+exec haproxy -W -db -f haproxy.cfg

--- a/examples/haproxy/haproxy.cfg
+++ b/examples/haproxy/haproxy.cfg
@@ -1,5 +1,6 @@
 global
     log stdout format raw local0
+    stats socket /tmp/haproxy-admin.sock mode 660 level admin
 
 defaults
     mode http
@@ -19,13 +20,22 @@ frontend test
     bind *:8080
     log-format "%ci:%cp\ [%t]\ %ft\ %b/%s\ %Th/%Ti/%TR/%Tq/%Tw/%Tc/%Tr/%Tt\ %ST\ %B\ %CC\ %CS\ %tsc\ %ac/%fc/%bc/%sc/%rc\ %sq/%bq\ %hr\ %hs\ %{+Q}r\ %ID spoa-error:\ %[var(txn.berghain.error)]"
 
-    http-request track-sc1 src table st_src
+    http-request set-var(req.berghain.host) req.hdr(host),lower,regsub(:[0-9]+$,,)
+    acl berghain_bypass var(req.berghain.host) -m str -f examples/haproxy/maps/bypass-hosts.lst
+
+    http-request set-var(req.berghain.reputation) src,map_ip(examples/haproxy/state/reputation.map,0)
+    acl reputation_block var(req.berghain.reputation) -m int eq 1
+    acl reputation_challenge var(req.berghain.reputation) -m int eq 3
+    http-request silent-drop if reputation_block !berghain_bypass
+
+    http-request track-sc1 src table st_src if !berghain_bypass
 
     filter spoe engine berghain config examples/haproxy/berghain.cfg
 
-    http-request set-var(req.berghain.level) int(1) if { sc1_http_req_rate gt 5 }
-    http-request set-var(req.berghain.level) int(2) if { sc1_http_req_rate gt 10 }
-    http-request set-var(req.berghain.level) int(3) if { sc1_http_req_rate gt 15 }
+    http-request set-var(req.berghain.level) int(1) if { sc1_http_req_rate gt 5 } !berghain_bypass
+    http-request set-var(req.berghain.level) int(2) if { sc1_http_req_rate gt 10 } !berghain_bypass
+    http-request set-var(req.berghain.level) int(3) if { sc1_http_req_rate gt 15 } !berghain_bypass
+    http-request set-var(req.berghain.level) int(3) if reputation_challenge !berghain_bypass
 
     acl berghain_active var(req.berghain.level) -m found
 

--- a/examples/haproxy/maps/bypass-hosts.lst
+++ b/examples/haproxy/maps/bypass-hosts.lst
@@ -1,0 +1,1 @@
+# Add one exact, lower-case hostname per line. Do not add wildcard suffixes.

--- a/examples/haproxy/state/reputation.map
+++ b/examples/haproxy/state/reputation.map
@@ -1,0 +1,3 @@
+# Seed entries keep the map registered for Runtime API transactions.
+0.0.0.0/32 0
+::/128 0


### PR DESCRIPTION
> Stacked on #72; this PR wires the validated updater into the example policy and container.

## What

- Load the reputation map and expose an admin Runtime API socket.
- Interpret action 1 as a silent drop and action 3 as challenge level 3.
- Replace arbitrary `.onion`/`.i2p` Host suffix bypasses with an exact lower-case hostname allowlist.
- Build and schedule the updater in the container, persist generated state in a writable named volume, and keep the operator allowlist read-only.
- Fix the image so it copies the SPOE configuration it references.

## Why

Any client can forge an HTTP Host suffix, so implicit hidden-service bypasses disable protection. The omnibus peers path was also not compatible with HAProxy. This policy uses exact operator intent and the supported Runtime API.

When combined with #65/#71, preserve the tested ordering: compute bypass/reputation first, then guard burst, ban, attempt, rate-level, and reputation controls with `!berghain_bypass`.

## Validation

- Go unit/race/vet/staticcheck and HAProxy config validation
- Real runtime transaction: blocked source reset the connection; exact bypass host reached the backend
- Docker image build and live container startup
- Compose backend 200 plus 1,387-entry live refresh
- Writable-volume ownership and rollback behavior