### PR TITLE
fix(web): use named imports from @babel/core

### DIFF
--- a/web/build/inline-hooks.js
+++ b/web/build/inline-hooks.js
@@ -1,9 +1,7 @@
 import {readFile, stat} from "node:fs/promises";
 import {dirname, isAbsolute, relative, resolve, sep} from "node:path";
-import babel from "@babel/core";
+import {parseAsync, transformFromAstAsync, traverse, types} from "@babel/core";
 import {searchForWorkspaceRoot} from "vite";
-
-const {parseAsync, transformFromAstAsync, traverse, types} = babel;
 
 const MARKER_TOKEN = "@berghain:inline";
 const SENTINEL = "__BERGHAIN_INLINE_PHASE__";


### PR DESCRIPTION
## Summary
The dependabot bump to `@babel/core` 8.0.1 (a4c8974) broke CI: Babel 8 is native ESM and no longer provides a default export, so `import babel from "@babel/core"` in `web/build/inline-hooks.js` threw `SyntaxError: The requested module '@babel/core' does not provide an export named 'default'`. This failed the Vite config load in both the **JS** workflow (lint/test/build) and the **Go** workflow (e2e web bundle build).

Babel 8 still exposes `parseAsync`, `transformFromAstAsync`, `traverse`, and `types` as named exports, so the fix is to import them directly.

## Test plan
- `npm ci && npm run lint` — clean
- `npm run test` — 10/10 pass (previously 4/5 with the inline-hooks suite failing to load)
- `npm run build` — both bundle variants build

🤖 Generated with [Claude Code](https://claude.com/claude-code)