### PR TITLE
feat(web): render captcha widgets for turnstile, hcaptcha, and recaptcha

### DIFF
--- a/web/build/inline-hooks.js
+++ b/web/build/inline-hooks.js
@@ -1,9 +1,7 @@
 import {readFile, stat} from "node:fs/promises";
 import {dirname, isAbsolute, relative, resolve, sep} from "node:path";
-import babel from "@babel/core";
+import {parseAsync, transformFromAstAsync, traverse, types} from "@babel/core";
 import {searchForWorkspaceRoot} from "vite";
-
-const {parseAsync, transformFromAstAsync, traverse, types} = babel;
 
 const MARKER_TOKEN = "@berghain:inline";
 const SENTINEL = "__BERGHAIN_INLINE_PHASE__";

--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,7 @@
         <div class="checkmark draw"></div>
         <div class="cross draw"></div>
       </div>
+      <div id="captcha-widget" class="captcha-widget" style="display: none"></div>
     </div>
     <noscript>
       <p>

--- a/web/src/challange/capabilities.js
+++ b/web/src/challange/capabilities.js
@@ -1,3 +1,14 @@
+/**
+ * Advice shown when a captcha provider script cannot be loaded, the
+ * most common cause being a content blocker. Unlike the capabilities
+ * below this can only be detected once loading the script has failed.
+ */
+export const captchaBlockedAdvice = Object.freeze({
+    name: "Captcha provider",
+    message: "The captcha provider script could not be loaded.",
+    fix: "Disable content blockers for this page, check your network connection, and reload.",
+});
+
 const advice = {
     textEncoder: {
         name: "Text encoding",

--- a/web/src/challange/challanger.js
+++ b/web/src/challange/challanger.js
@@ -51,6 +51,9 @@ export async function doChallenge(){
         }
     }
     catch (e){
+        if (e.advice){
+            loader.showCapabilities([e.advice]);
+        }
         result = e.toString();
     }
 

--- a/web/src/challange/challanges.js
+++ b/web/src/challange/challanges.js
@@ -4,6 +4,8 @@
 
 import {sha256} from "@noble/hashes/sha256";
 import {bytesToHex} from "@noble/hashes/utils";
+import {captchaBlockedAdvice} from "./capabilities.js";
+import * as loader from "./loader.js";
 
 async function doHash(data){
     const input = new TextEncoder().encode(data);
@@ -61,12 +63,133 @@ async function challengeNone(){
     });
 }
 
+export const captchaProviders = Object.freeze({
+    3: Object.freeze({
+        name: "Turnstile",
+        script: "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit",
+        global: "turnstile",
+    }),
+    4: Object.freeze({
+        name: "hCaptcha",
+        script: "https://js.hcaptcha.com/1/api.js?render=explicit",
+        global: "hcaptcha",
+        // hcaptcha initializes asynchronously after the script has
+        // loaded and signals readiness via a named onload callback.
+        useOnload: true,
+    }),
+    5: Object.freeze({
+        name: "reCAPTCHA",
+        script: "https://www.google.com/recaptcha/api.js?render=explicit",
+        global: "grecaptcha",
+        // grecaptcha initializes asynchronously after the script has
+        // loaded and queues ready() callbacks until then. Turnstile and
+        // hCaptcha are usable directly; turnstile.ready() even throws
+        // when the script was loaded async.
+        useReady: true,
+    }),
+});
+
+const captchaOnloadCallback = "__berghainCaptchaLoaded";
+
+function loadProviderScript(provider, environment){
+    return new Promise((resolve, reject) => {
+        const script = environment.document.createElement("script");
+        script.src = provider.script;
+        if (provider.useOnload){
+            environment[captchaOnloadCallback] = () => {
+                delete environment[captchaOnloadCallback];
+                resolve();
+            };
+            script.src += `&onload=${captchaOnloadCallback}`;
+        }
+        else {
+            script.onload = () => resolve();
+        }
+        script.async = true;
+        script.onerror = () => reject(new Error(`Failed to load ${script.src}`));
+        environment.document.head.append(script);
+    });
+}
+
+/**
+ * Load the widget API of a captcha provider.
+ *
+ * @param {{name: string, script: string, global: string}} provider
+ * @param {object} environment
+ * @return {Promise<object>}
+ */
+async function loadCaptchaApi(provider, environment){
+    let api;
+    try {
+        await loadProviderScript(provider, environment);
+        api = environment[provider.global];
+    }
+    catch {
+        api = undefined;
+    }
+
+    if (!api){
+        const error = new Error(`${provider.name} is unavailable.`);
+        error.advice = captchaBlockedAdvice;
+        throw error;
+    }
+
+    if (provider.useReady){
+        await new Promise((resolve) => api.ready(resolve));
+    }
+
+    return api;
+}
+
+/**
+ * Challenge captcha. Renders the provider widget and submits its
+ * response token for validation.
+ *
+ * @param {object} challenge
+ * @param {{environment?: object}} [options]
+ * @return {Promise<void>}
+ */
+export async function challengeCaptcha(challenge, {environment = globalThis} = {}){
+    const provider = captchaProviders[challenge.t];
+    const api = await loadCaptchaApi(provider, environment);
+
+    const container = loader.showWidget();
+    let token;
+    try {
+        token = await new Promise((resolve, reject) => {
+            api.render(container, {
+                sitekey: challenge.k,
+                callback: resolve,
+                "error-callback": () => reject(new Error(`${provider.name} reported a widget error`)),
+            });
+        });
+    }
+    finally {
+        loader.hideWidget();
+    }
+
+    const response = await environment.fetch("/cdn-cgi/challenge-platform/challenge", {
+        body: token,
+        headers: {
+            "Content-Type": "text/plain",
+        },
+        method: "POST",
+    });
+    if (!response.ok){
+        throw new Error("Challenge submission failed");
+    }
+}
+
 export function getChallengeSolver(challengeType){
     switch (challengeType){
         case 0:
             return ["Please wait...", challengeNone];
         case 1:
             return ["Solving POW challenge...", challengePOW];
+        case 3:
+        case 4:
+        case 5:
+            return [`Waiting for ${captchaProviders[challengeType].name}...`, challengeCaptcha];
         default:
             throw new Error(`Unknown challenge type: ${challengeType}`);
     }

--- a/web/src/challange/loader.js
+++ b/web/src/challange/loader.js
@@ -49,6 +49,29 @@ export function showCapabilities(missing){
     container.style.display = "block";
 }
 
+/**
+ * Show the captcha widget mount point instead of the spinner.
+ *
+ * @return {HTMLDivElement} The widget container.
+ */
+export function showWidget(){
+    const widget = /** @type {HTMLDivElement} */ (document.getElementById("captcha-widget"));
+    const loader = /** @type {HTMLDivElement} */ (document.querySelector(".circle-loader"));
+    loader.style.display = "none";
+    widget.style.display = "block";
+    return widget;
+}
+
+/**
+ * Hide the captcha widget and bring the spinner back.
+ */
+export function hideWidget(){
+    const widget = /** @type {HTMLDivElement} */ (document.getElementById("captcha-widget"));
+    const loader = /** @type {HTMLDivElement} */ (document.querySelector(".circle-loader"));
+    widget.style.display = "none";
+    loader.style.display = "";
+}
+
 export function setChallengeInfo(text){
     const captcha = /** @type {HTMLDivElement} */ (document.querySelector(".captcha"));
     captcha.innerText = text;

--- a/web/src/style.scss
+++ b/web/src/style.scss
@@ -82,6 +82,10 @@ code {
     font-size: 120%;
 }
 
+.captcha-widget {
+    margin-left: 1em;
+}
+
 $circleSize: 3em;
 
 .circle-loader {

--- a/web/test/challanges.test.js
+++ b/web/test/challanges.test.js
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {captchaBlockedAdvice} from "../src/challange/capabilities.js";
+import {captchaProviders, challengeCaptcha, getChallengeSolver} from "../src/challange/challanges.js";
+
+function scriptEnvironment(onScript){
+    return {
+        document: {
+            createElement: () => ({}),
+            head: {
+                append(script){
+                    queueMicrotask(() => onScript(script));
+                },
+            },
+        },
+    };
+}
+
+test("describes every captcha challenge type", () => {
+    assert.deepEqual(Object.keys(captchaProviders), ["3", "4", "5"]);
+
+    for (const provider of Object.values(captchaProviders)){
+        assert.match(provider.script, /^https:\/\//);
+        assert.notEqual(provider.name, "");
+        assert.notEqual(provider.global, "");
+    }
+});
+
+test("solves captcha challenge types with the captcha solver", () => {
+    for (const [challengeType, provider] of Object.entries(captchaProviders)){
+        const [name, solver] = getChallengeSolver(Number(challengeType));
+        assert.equal(solver, challengeCaptcha);
+        assert.match(name, new RegExp(provider.name));
+    }
+
+    assert.throws(() => getChallengeSolver(99), /Unknown challenge type/);
+});
+
+test("advises about content blockers when the provider script fails to load", async() => {
+    const environment = scriptEnvironment((script) => script.onerror(new Error("blocked")));
+
+    await assert.rejects(challengeCaptcha({k: "sitekey", t: 3}, {environment}), (error) => {
+        assert.match(error.message, /Turnstile/);
+        assert.equal(error.advice, captchaBlockedAdvice);
+        return true;
+    });
+});
+
+test("advises about content blockers when the provider API is missing after load", async() => {
+    const environment = scriptEnvironment((script) => script.onload());
+
+    await assert.rejects(challengeCaptcha({k: "sitekey", t: 3}, {environment}), (error) => {
+        assert.match(error.message, /Turnstile/);
+        assert.equal(error.advice, captchaBlockedAdvice);
+        return true;
+    });
+});
+
+test("renders the widget and submits its token", async() => {
+    const requests = [];
+    const rendered = [];
+    const widget = {style: {}};
+
+    const environment = scriptEnvironment((script) => {
+        // hcaptcha signals readiness through the named onload callback.
+        const callbackName = new URL(script.src).searchParams.get("onload");
+        assert.notEqual(callbackName, null);
+        environment[callbackName]();
+    });
+    environment.fetch = async(url, options) => {
+        requests.push({options, url});
+        return {ok: true};
+    };
+    environment.hcaptcha = {
+        render(container, options){
+            rendered.push({container, options});
+            queueMicrotask(() => options.callback("widget-response-token"));
+        },
+    };
+
+    globalThis.document = {
+        getElementById: () => widget,
+        querySelector: () => ({style: {}}),
+    };
+    try {
+        await challengeCaptcha({k: "sitekey-under-test", t: 4}, {environment});
+    }
+    finally {
+        delete globalThis.document;
+    }
+
+    assert.equal(rendered[0].container, widget);
+    assert.equal(rendered[0].options.sitekey, "sitekey-under-test");
+    assert.equal(requests[0].url, "/cdn-cgi/challenge-platform/challenge");
+    assert.equal(requests[0].options.method, "POST");
+    assert.equal(requests[0].options.body, "widget-response-token");
+});


### PR DESCRIPTION
## Summary
Second of three captcha PRs (server #75 → **web** → integration/e2e). Stacked on #74 so CI can build the web bundle; GitHub will retarget to master once #74 merges.

Adds the browser side for challenge types `t:3` (Turnstile), `t:4` (hCaptcha), `t:5` (reCAPTCHA v2): one shared solver that injects the provider script, renders the widget in explicit mode where the spinner sits, and POSTs the response token exactly like the POW solver. The challenge JSON's `k` field carries the sitekey; script URLs are hardcoded client-side so the external-domain allowlist stays auditable.

Provider quirks (found by actually driving the page, each documented in the descriptor table):
- **Turnstile** is usable straight after script load — `turnstile.ready()` *throws* for async-loaded scripts.
- **grecaptcha** initializes asynchronously and queues `ready()` callbacks, so it opts into `useReady`.
- **hCaptcha** signals readiness via a named `onload=` callback, so it opts into `useOnload` (skipping this triggers a documented race warning).

A blocked provider script — the dominant real-world failure, usually content blockers — surfaces actionable advice through the existing capability-advice UI instead of a bare error string.

## Test plan
- `npm run lint`, `npm test` (15/15, five new: provider table completeness, solver dispatch, blocked-script and missing-API advice paths, full render-and-submit happy path with a mocked provider), `npm run build`.
- Drove the built bundle in headless Chrome against a mock challenge endpoint:
  - Turnstile with Cloudflare's always-pass dummy sitekey: widget renders, auto-solves, token (`XXXX.DUMMY.TOKEN.XXXX`) POSTed to the challenge endpoint, success state + reload countdown.
  - hCaptcha and reCAPTCHA with their public test sitekeys: widgets render with no console warnings or errors (solving needs human interaction; the verify logic is server-side, covered in #75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)